### PR TITLE
Bug fix: Lexicon without section

### DIFF
--- a/base.php
+++ b/base.php
@@ -941,9 +941,9 @@ final class Base extends Prefab implements ArrayAccess {
 						$prefix='';
 						foreach ($matches as $match)
 							if ($match['prefix'])
-								$prefix=$match['prefix'];
+								$prefix=$match['prefix'].'.';
 							elseif (!array_key_exists(
-								$key=$prefix.'.'.$match['lval'],$lex))
+								$key=$prefix.$match['lval'],$lex))
 								$lex[$key]=trim(preg_replace(
 									'/\\\\\h*\r?\n/','',$match['rval']));
 					}


### PR DESCRIPTION
Existing dictionaries (without section) were not working anymore because of the leading dot.
