### PR TITLE
Trim spaces in language() function

### DIFF
--- a/base.php
+++ b/base.php
@@ -884,7 +884,7 @@ final class Base extends Prefab implements ArrayAccess {
 	*	@param $code string
 	**/
 	function language($code) {
-		$code=preg_replace('/;q=.+?(?=,|$)/','',$code);
+		$code=preg_replace('/\h+|;q=[0-9.]+/','',$code);
 		$code.=($code?',':'').$this->fallback;
 		$this->languages=array();
 		foreach (array_reverse(explode(',',$code)) as $lang) {


### PR DESCRIPTION
Currently, a header such as `Accept-Language: da, en-gb;q=0.8, en;q=0.7` is not correctly parsed, although it is valid.
