### PR TITLE
Bugfix: regex group 4 not captured in $f3->route

### DIFF
--- a/base.php
+++ b/base.php
@@ -1203,7 +1203,7 @@ final class Base extends Prefab implements ArrayAccess {
 				$this->route($item,$handler,$ttl,$kbps);
 			return;
 		}
-		preg_match('/([\|\w]+)\h+(?:(?:@(\w+)\h*:\h*)?([^\h]+)|@(\w+))'.
+		preg_match('/([\|\w]+)\h+(?:(?:@(\w+)\h*:\h*)?(@(\w+)|[^\h]+))'.
 			'(?:\h+\[('.implode('|',$types).')\])?/',$pattern,$parts);
 		if (isset($parts[2]) && $parts[2])
 			$this->hive['ALIASES'][$alias=$parts[2]]=$parts[3];


### PR DESCRIPTION
This PR intends to fix this:

```
GET  @named : /404 = App->page404
POST @named        = App->nowhere <-- doesn't work
```
