### PR TITLE
Escape implicit HIVEs for sub-Views, fixes #749

### DIFF
--- a/base.php
+++ b/base.php
@@ -2306,9 +2306,12 @@ class View extends Prefab {
 	protected function sandbox(array $hive=NULL) {
 		$this->level++;
 		$fw=Base::instance();
-		if (!$hive)
+		$implicit=false;
+		if (!$hive) {
+			$implicit=true;
 			$hive=$fw->hive();
-		if ($this->level<2) {
+		}
+		if ($this->level<2 || $implicit) {
 			if ($fw->get('ESCAPE'))
 				$hive=$this->esc($hive);
 			if (isset($hive['ALIASES']))


### PR DESCRIPTION
This pull request should fix [#749](https://github.com/bcosca/fatfree/issues/749). It passes the test cases for `Template` and `View` (see [#750](https://github.com/bcosca/fatfree/pull/750)).
