### PR TITLE
Use [], instead of array_push() in Base::push(). Faster, minor convenience.

### DIFF
--- a/base.php
+++ b/base.php
@@ -524,7 +524,7 @@ final class Base extends Prefab implements ArrayAccess {
 	**/
 	function push($key,$val) {
 		$ref=&$this->ref($key);
-		array_push($ref,$val);
+		$ref[] = $val;
 		return $val;
 	}
 


### PR DESCRIPTION
One liner. Use [], instead of array_push() in Base::push(). Its faster, and a minor convenience to user. Difference is if key is undefined in hive an array is created, instead of fatal error. If its defined but not and array, no change - PHP_WARNING, which becomes fatal by default.

I think most people expect the `[]` syntactic short cut semantics these days - I did.  Can't imagine this hasn't come up before though, some maybe there is a good reason for using array_push() that I missed? Could not find issue.

Will PR modified tests to bcosca/fatree shortly.