### PR TITLE
Fix missing newlines after template expansion

### DIFF
--- a/base.php
+++ b/base.php
@@ -2412,7 +2412,7 @@ class Preview extends View {
 							'->'.$func.'('.$str.')';
 				}
 				return '<?php echo '.$str.'; ?>'.
-					(isset($expr[3])?$expr[3]:'');
+					(isset($expr[3])?$expr[3]."\n":'');
 			},
 			preg_replace_callback(
 				'/\{~(.+?)~\}/s',


### PR DESCRIPTION
This is a repeat of https://github.com/bcosca/fatfree/commit/970c97580b84d07b856172683afd84ffb82a9b63 that someone since broke.