### PR TITLE
Do not name a custom variable `$this` (not allowed)

### DIFF
--- a/base.php
+++ b/base.php
@@ -1294,8 +1294,8 @@ final class Base extends Prefab implements ArrayAccess {
 				$this->redirect($item,$url);
 			return;
 		}
-		$this->route($pattern,function($this) use($url) {
-			$this->reroute($url);
+		$this->route($pattern,function($fw) use($url) {
+			$fw->reroute($url);
 		});
 	}
 


### PR DESCRIPTION
Without this change the `redirect` function fails with the following message (using PHP 5.3.10):

    Fatal error: Using $this when not in object context