### PR TITLE
Update error handler to not error on `E_NOTICE`

### DIFF
--- a/base.php
+++ b/base.php
@@ -1844,7 +1844,7 @@ final class Base extends Prefab implements ArrayAccess {
 		@ini_set('magic_quotes_gpc',0);
 		@ini_set('register_globals',0);
 		// Intercept errors/exceptions; PHP5.3-compatible
-		error_reporting((E_ALL|E_STRICT)&~E_NOTICE);
+		error_reporting((E_ALL|E_STRICT)&~(E_NOTICE|E_USER_NOTICE));
 		$fw=$this;
 		set_exception_handler(
 			function($obj) use($fw) {
@@ -1854,7 +1854,7 @@ final class Base extends Prefab implements ArrayAccess {
 		);
 		set_error_handler(
 			function($code,$text) use($fw) {
-				if (error_reporting())
+				if ($code & error_reporting())
 					$fw->error(500,$text);
 			}
 		);


### PR DESCRIPTION
This was previously submitted as bcosca/fatfree#646 — since then `E_NOTICE` has been exempt from default error reporting (bcosca/fatfree@29d77780c9954efc857030eb46836d7a56b54006) which makes this commit even more relevant.

Also exempted `E_USER_NOTICE` since that isn’t an error either.