### PR TITLE
allow sql mapper to return table name

### DIFF
--- a/db/sql/mapper.php
+++ b/db/sql/mapper.php
@@ -55,6 +55,14 @@ class Mapper extends \DB\Cursor {
 	}
 
 	/**
+	*	Return mapped table
+	*	@return string
+	**/
+	function table() {
+		return $this->source;
+	}
+
+	/**
 	*	Return TRUE if field is defined
 	*	@return bool
 	*	@param $key string


### PR DESCRIPTION
Use case:

A conceptual 'entity' may comprise of several tables in a system with poor data structure.

When passing mapper objects around, currently there is no lightweight fat-free method to check they have mapped the correct table for their intended usage. The lightest way is currently to compare schema's which feels needless. This solves that issue simply. 