### PR TITLE
Suggestion: allow array input in copyfrom() methods

### DIFF
--- a/basket.php
+++ b/basket.php
@@ -189,10 +189,12 @@ class Basket extends Magic {
 	/**
 	*	Hydrate item using hive array variable
 	*	@return NULL
-	*	@param $key string
+	*	@param $var array|string
 	**/
-	function copyfrom($key) {
-		foreach (\Base::instance()->get($key) as $key=>$val)
+	function copyfrom($var) {
+		if (is_string($var))
+			$var=\Base::instance()->get($var);
+		foreach ($var as $key=>$val)
 			$this->item[$key]=$val;
 	}
 

--- a/db/cursor.php
+++ b/db/cursor.php
@@ -89,10 +89,10 @@ abstract class Cursor extends \Magic implements \IteratorAggregate {
 	/**
 	*	Hydrate mapper object using hive array variable
 	*	@return NULL
-	*	@param $key string
+	*	@param $var array|string
 	*	@param $func callback
 	**/
-	abstract function copyfrom($key,$func=NULL);
+	abstract function copyfrom($var,$func=NULL);
 
 	/**
 	*	Populate hive array variable with mapper fields

--- a/db/jig/mapper.php
+++ b/db/jig/mapper.php
@@ -420,11 +420,12 @@ class Mapper extends \DB\Cursor {
 	/**
 	*	Hydrate mapper object using hive array variable
 	*	@return NULL
-	*	@param $key string
+	*	@param $var array|string
 	*	@param $func callback
 	**/
-	function copyfrom($key,$func=NULL) {
-		$var=\Base::instance()->get($key);
+	function copyfrom($var,$func=NULL) {
+		if (is_string($var))
+			$var=\Base::instance()->get($var);
 		if ($func)
 			$var=call_user_func($func,$var);
 		foreach ($var as $key=>$val)

--- a/db/mongo/mapper.php
+++ b/db/mongo/mapper.php
@@ -297,11 +297,12 @@ class Mapper extends \DB\Cursor {
 	/**
 	*	Hydrate mapper object using hive array variable
 	*	@return NULL
-	*	@param $key string
+	*	@param $var array|string
 	*	@param $func callback
 	**/
-	function copyfrom($key,$func=NULL) {
-		$var=\Base::instance()->get($key);
+	function copyfrom($var,$func=NULL) {
+		if (is_string($var))
+			$var=\Base::instance()->get($var);
 		if ($func)
 			$var=call_user_func($func,$var);
 		foreach ($var as $key=>$val)

--- a/db/sql/mapper.php
+++ b/db/sql/mapper.php
@@ -531,11 +531,12 @@ class Mapper extends \DB\Cursor {
 	/**
 	*	Hydrate mapper object using hive array variable
 	*	@return NULL
-	*	@param $key string
+	*	@param $var array|string
 	*	@param $func callback
 	**/
-	function copyfrom($key,$func=NULL) {
-		$var=\Base::instance()->get($key);
+	function copyfrom($var,$func=NULL) {
+		if (is_string($var))
+			$var=\Base::instance()->get($var);
 		if ($func)
 			$var=call_user_func($func,$var);
 		foreach ($var as $key=>$val)


### PR DESCRIPTION
Hi,
this PR intends to allow such calls:
```php
$myinput=array(...);
$mapper->copyfrom($myinput);
```
which, at the moment, cannot be achieved without pushing the data into the framework hive:
```php
$myinput=array(...);
$f3->set('myinput',$myinput);
$mapper->copyfrom('myinput');
```