### PR TITLE
Move composer.js to composer.json. Remove self ref repository section

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,12 +6,6 @@
 	"require": {
 		"php": ">=5.3.6"
 	},
-	"repositories": [
-		{
-			"type": "vcs",
-			"url": "https://github.com/bcosca/fatfree-core"
-		}
-	],
 	"autoload": {
 		"files": ["base.php"]
 	}


### PR DESCRIPTION
Minor tidy up in composer.json. Not sure why it was called "composer.js", but composer will not find it named this way, so moved it. Also removed redundant repositories section. Tested, works with:

    {
	    "name": "test",
	    "require": {
		    "bcosca/fatfree-core": "dev-master"
	    },
	    "repositories": [
		    {
			    "type": "vcs",
			    "url": "https://github.com/sam-at-github/fatfree-core"
		    }
	    ]
    } 