### PR TITLE
Deprecate implicit construction

### DIFF
--- a/base.php
+++ b/base.php
@@ -2929,4 +2929,3 @@ final class Registry {
 
 }
 
-return Base::instance();

--- a/composer.json
+++ b/composer.json
@@ -7,6 +7,6 @@
 		"php": ">=5.3.6"
 	},
 	"autoload": {
-		"autoload": ["lib/"]
+		"classmap": ["."]
 	}
 }


### PR DESCRIPTION
It's bad practice IMHO to do anything non declarative from an included file/module. The only reason this used to be done is to get the F3 autoloader to load. That is not needed given the changes to composer.json in #31. The f3 autoloader is still there underneath the composer autoloader. If your not using composer you now do:

    require 'path/to/Base.php';
    $f3 = \Base::instance();

Otherwise, with composer (#31) its:

    require 'vendor/autoloader.php';
    $f3 = \Base::instance();