### PR TITLE
Image + minify: allow absolute paths

### DIFF
--- a/base.php
+++ b/base.php
@@ -586,10 +586,11 @@ final class Base extends Prefab implements ArrayAccess {
 	*	Split comma-, semi-colon, or pipe-separated string
 	*	@return array
 	*	@param $str string
+	*	@param $noempty bool
 	**/
-	function split($str) {
+	function split($str,$noempty=TRUE) {
 		return array_map('trim',
-			preg_split('/[,;|]/',$str,0,PREG_SPLIT_NO_EMPTY));
+			preg_split('/[,;|]/',$str,0,$noempty?PREG_SPLIT_NO_EMPTY:0));
 	}
 
 	/**

--- a/image.php
+++ b/image.php
@@ -26,6 +26,7 @@ class Image {
 	//@{ Messages
 	const
 		E_Color='Invalid color specified: %s',
+		E_File='File not found',
 		E_Font='CAPTCHA font not found',
 		E_Length='Invalid CAPTCHA length: %s';
 	//@}
@@ -560,15 +561,18 @@ class Image {
 	*	@param $flag bool
 	*	@param $path string
 	**/
-	function __construct($file=NULL,$flag=FALSE,$path='') {
+	function __construct($file=NULL,$flag=FALSE,$path=NULL) {
 		$this->flag=$flag;
 		if ($file) {
 			$fw=Base::instance();
 			// Create image from file
 			$this->file=$file;
-			foreach ($fw->split($path?:$fw->get('UI').';./') as $dir)
+			if (!isset($path))
+				$path=$fw->get('UI').';./';
+			foreach ($fw->split($path,FALSE) as $dir)
 				if (is_file($dir.$file))
 					return $this->load($fw->read($dir.$file));
+			user_error(self::E_File,E_USER_ERROR);
 		}
 	}
 

--- a/web.php
+++ b/web.php
@@ -537,7 +537,7 @@ class Web extends Prefab {
 	*	@param $header bool
 	*	@param $path string
 	**/
-	function minify($files,$mime=NULL,$header=TRUE,$path='') {
+	function minify($files,$mime=NULL,$header=TRUE,$path=NULL) {
 		$fw=Base::instance();
 		if (is_string($files))
 			$files=$fw->split($files);
@@ -546,7 +546,9 @@ class Web extends Prefab {
 		preg_match('/\w+$/',$files[0],$ext);
 		$cache=Cache::instance();
 		$dst='';
-		foreach ($fw->split($path?:$fw->get('UI').';./') as $dir)
+		if (!isset($path))
+			$path=$fw->get('UI').';./';
+		foreach ($fw->split($path,FALSE) as $dir)
 			foreach ($files as $file)
 				if (is_file($save=$fw->fixslashes($dir.$file))) {
 					if ($fw->get('CACHE') &&


### PR DESCRIPTION
Hi,
this is an alternative to https://github.com/bcosca/fatfree-core/pull/34.
Here we keep the existing logic, with the only difference that `$path` can be set to an empty string, thus allowing `$file(s)` to contain absolute paths.