### PR TITLE
SQL mapper: force adhoc value on adhoc fields

### DIFF
--- a/db/sql/mapper.php
+++ b/db/sql/mapper.php
@@ -101,7 +101,10 @@ class Mapper extends \DB\Cursor {
 			return $this->fields[$key]['value']=$val;
 		}
 		// Parenthesize expression in case it's a subquery
-		$this->adhoc[$key]=array('expr'=>'('.$val.')','value'=>NULL);
+		if (isset($this->adhoc[$key]))
+			$this->adhoc[$key]['value']=$val;
+		else
+			$this->adhoc[$key]=array('expr'=>'('.$val.')','value'=>NULL);
 		return $val;
 	}
 


### PR DESCRIPTION
This is a suggestion to fix the issue raised in https://github.com/bcosca/fatfree/issues/757.

Here's a code to reproduce the bug:
```php
class Project extends DB\SQL\Mapper {
  function __construct($db) {
    parent::__construct($db,'projects');
    $this->set('upper','UPPER(name)');
  }
}
$project=new Project($db);
$project->load();
echo $project->upper;// FATFREE
$project=View::instance()->esc($project);//hive escape
echo $project->upper;// NULL
```

The suggested fix is based on the assumption that the definition of adhoc fields are not meant to change.