### PR TITLE
No implicit construction in base.php

### DIFF
--- a/base.php
+++ b/base.php
@@ -3008,5 +3008,3 @@ final class Registry {
 	}
 
 }
-
-return Base::instance();


### PR DESCRIPTION
One liner. rm `Base::instance()` on load construction. Bad practice. Causes issues. Had pushed this earlier, but accidently deleted PR branch.