### PR TITLE
MongoCollection::count method compatibility fix for latest driver

### DIFF
--- a/db/mongo/mapper.php
+++ b/db/mongo/mapper.php
@@ -206,7 +206,7 @@ class Mapper extends \DB\Cursor {
 		if (!($cached=$cache->exists($hash=$fw->hash($fw->stringify(
 			array($filter))).'.mongo',$result)) || !$ttl ||
 			$cached[0]+$ttl<microtime(TRUE)) {
-			$result=$this->collection->count($filter);
+			$result=$this->collection->count($filter?:array());
 			if ($fw->get('CACHE') && $ttl)
 				// Save to cache backend
 				$cache->set($hash,$result,$ttl);


### PR DESCRIPTION
I just created a new fresh clean mongo+php setup and run into a 500.
In your [comment about that issue](https://groups.google.com/d/msg/f3-framework/nqeQKQb3V7E/QpjvF9KYAgMJ) you already stated this as an upstream bug. I crawled through the php mongo driver history and found this: https://github.com/mongodb/mongo-php-driver/commit/f7aa7fe9412ee534d1cf77230975f7bc57a1e2cb

from the commit message regarding the `$filter` argument:
> [...] Previously, an invalid type for this argument was ignored and passed through to the server (where it was likely ignored). The lack of validation may have been an oversight, [...]

So i think they just added a bit more strict validation checks here to force the argument to be an array. Hence this PR.