### PR TITLE
Router fix: loose method search

### DIFF
--- a/base.php
+++ b/base.php
@@ -1500,8 +1500,7 @@ final class Base extends Prefab implements ArrayAccess {
 				}
 				return $result;
 			}
-			$allowed=array_keys($route);
-			break;
+			$allowed=array_merge($allowed,array_keys($route));
 		}
 		if (!$allowed)
 			// URL doesn't match any route

--- a/base.php
+++ b/base.php
@@ -1507,7 +1507,7 @@ final class Base extends Prefab implements ArrayAccess {
 			$this->error(404);
 		elseif (PHP_SAPI!='cli') {
 			// Unhandled HTTP method
-			header('Allow: '.implode(',',$allowed));
+			header('Allow: '.implode(',',array_unique($allowed)));
 			if ($this->hive['VERB']!='OPTIONS')
 				$this->error(405);
 		}


### PR DESCRIPTION
This PR intends to fix [this](https://groups.google.com/forum/#!topic/f3-framework/hyhFDTA0XvY).

In a nutshell, when we define:
* `POST /foo`
* `GET /@token`

`GET /foo` should be valid (it returns 405 at the moment).