### PR TITLE
View: Removed reserved variables $fw and $implicit

### DIFF
--- a/base.php
+++ b/base.php
@@ -2463,9 +2463,9 @@ class View extends Prefab {
 			if (isset($hive['ALIASES']))
 				$hive['ALIASES']=$fw->build($hive['ALIASES']);
 		}
+		unset($fw, $implicit);
 		extract($hive);
 		unset($hive);
-		unset($fw);
 		ob_start();
 		require($this->view);
 		$this->level--;


### PR DESCRIPTION
This pull request removes the reserved sandbox variable `$fw` and cleans the sandbox from default `$implicit` definitions.

Now it's possible to use the `$fw` variable in HIVEs and `$implicit` is no longer part of sandbox environments.

Remaining reserved variables: `$this` and `$hive`.

We could also remove `$hive` from the reserved variables by copying it to a temporary member variable.