### PR TITLE
keep reference to Jig table, bcosca/fatfree#758

### DIFF
--- a/db/jig.php
+++ b/db/jig.php
@@ -48,12 +48,13 @@ class Jig {
 	*	@return array
 	*	@param $file string
 	**/
-	function read($file) {
-		if (!$this->dir)
-			return isset($this->data[$file])?$this->data[$file]:array();
+	function &read($file) {
+		if (!$this->dir || !is_file($dst=$this->dir.$file)) {
+			if (!isset($this->data[$file]))
+				$this->data[$file]=array();
+			return $this->data[$file];
+		}
 		$fw=\Base::instance();
-		if (!is_file($dst=$this->dir.$file))
-			return array();
 		$raw=$fw->read($dst);
 		switch ($this->format) {
 			case self::FORMAT_JSON:
@@ -63,7 +64,8 @@ class Jig {
 				$data=$fw->unserialize($raw);
 				break;
 		}
-		return $data;
+		$this->data[$file] = $data;
+		return $this->data[$file];
 	}
 
 	/**

--- a/db/jig/mapper.php
+++ b/db/jig/mapper.php
@@ -320,15 +320,15 @@ class Mapper extends \DB\Cursor {
 		$db=$this->db;
 		$now=microtime(TRUE);
 		while (($id=uniqid(NULL,TRUE)) &&
-			($data=$db->read($this->file)) && isset($data[$id]) &&
+			($data=&$db->read($this->file)) && isset($data[$id]) &&
 			!connection_aborted())
 			usleep(mt_rand(0,100));
 		$this->id=$id;
-		$data[$id]=$this->document;
 		$pkey=array('_id'=>$this->id);
 		if (isset($this->trigger['beforeinsert']))
 			\Base::instance()->call($this->trigger['beforeinsert'],
 				array($this,$pkey));
+		$data[$id]=$this->document;
 		$db->write($this->file,$data);
 		$db->jot('('.sprintf('%.1f',1e3*(microtime(TRUE)-$now)).'ms) '.
 			$this->file.' [insert] '.json_encode($this->document));
@@ -346,11 +346,11 @@ class Mapper extends \DB\Cursor {
 	function update() {
 		$db=$this->db;
 		$now=microtime(TRUE);
-		$data=$db->read($this->file);
-		$data[$this->id]=$this->document;
+		$data=&$db->read($this->file);
 		if (isset($this->trigger['beforeupdate']))
 			\Base::instance()->call($this->trigger['beforeupdate'],
 				array($this,array('_id'=>$this->id)));
+		$data[$this->id]=$this->document;
 		$db->write($this->file,$data);
 		$db->jot('('.sprintf('%.1f',1e3*(microtime(TRUE)-$now)).'ms) '.
 			$this->file.' [update] '.json_encode($this->document));
@@ -368,7 +368,7 @@ class Mapper extends \DB\Cursor {
 	function erase($filter=NULL) {
 		$db=$this->db;
 		$now=microtime(TRUE);
-		$data=$db->read($this->file);
+		$data=&$db->read($this->file);
 		$pkey=array('_id'=>$this->id);
 		if ($filter) {
 			foreach ($this->find($filter,NULL,FALSE) as $mapper)


### PR DESCRIPTION
This approach intends to fix bcosca/fatfree#758. The problem in this issue was that updating the `$self` mapper within an event handler was ignored, since its document data was already mapped to the db entry before the event handler is triggered.
This was not the only issue here. When you try to invoke a new mapper or alter the same jig table of a mapper within an event handler, the changes made to the table array didn't had any effect, because the table `$data` was already read from the db file and writing it down again would overwrite any changes made in an event handler. Instead of reading the whole `$data` once more after calling the event to obtain the changes, I thought it would be smarter to keep a reference to the loaded table data. This way any changes to the table data are consistent.

here a little test. it's a generic way to add version-control to a mapper, which shows the issue (only store the last 3 records as backup)
```php
$f3->route('GET /jigtest', function($f3) {
    $f3->set('DB', new \DB\Jig('data/'));
    $mapper = new \DB\Jig\Mapper($f3['DB'],'test');
    $mapper->beforeupdate(function($self,$pkeys){
        $backup = new $self(\Base::instance()->get('DB'),'test');
        $backup->load(array('@_id = ?',$pkeys['_id']));
        $backup->copyto('backup');
        $backup->reset();
        $backup->copyfrom('backup');
        $backup->save();
        $self->version++;
        $self->erase(array('@version < ?',$self->version-3));
    });
    $mapper->beforeinsert(function($self,$pkeys){
        $self->version = 1;
    });

    $mapper->title = 'ABC';
    $mapper->text = \Web::instance()->filler(1,rand(3,8),false);
    $mapper->save();

    for($i=0;$i<10;$i++) {
      $mapper->reset();
      $mapper->load(array('@title = ? ','ABC'));
      $mapper->text = \Web::instance()->filler(1,rand(3,8),false);
      $mapper->save();
    }
});
```