### PR TITLE
improved mapper & collection type hints

### DIFF
--- a/db/cursor.php
+++ b/db/cursor.php
@@ -119,7 +119,7 @@ abstract class Cursor extends \Magic implements \IteratorAggregate {
 
 	/**
 	*	Return first record (mapper object) that matches criteria
-	*	@return object|FALSE
+	*	@return \DB\Cursor|FALSE
 	*	@param $filter string|array
 	*	@param $options array
 	*	@param $ttl int

--- a/db/jig/mapper.php
+++ b/db/jig/mapper.php
@@ -149,7 +149,7 @@ class Mapper extends \DB\Cursor {
 
 	/**
 	*	Return records that match criteria
-	*	@return array|FALSE
+	*	@return \DB\JIG\Mapper[]|FALSE
 	*	@param $filter array
 	*	@param $options array
 	*	@param $ttl int

--- a/db/mongo/mapper.php
+++ b/db/mongo/mapper.php
@@ -84,7 +84,7 @@ class Mapper extends \DB\Cursor {
 
 	/**
 	*	Convert array to mapper object
-	*	@return object
+	*	@return \DB\Mongo\Mapper
 	*	@param $row array
 	**/
 	protected function factory($row) {
@@ -111,7 +111,7 @@ class Mapper extends \DB\Cursor {
 
 	/**
 	*	Build query and execute
-	*	@return array
+	*	@return \DB\Mongo\Mapper[]
 	*	@param $fields string
 	*	@param $filter array
 	*	@param $options array
@@ -177,7 +177,7 @@ class Mapper extends \DB\Cursor {
 
 	/**
 	*	Return records that match criteria
-	*	@return array
+	*	@return \DB\Mongo\Mapper[]
 	*	@param $filter array
 	*	@param $options array
 	*	@param $ttl int

--- a/db/sql/mapper.php
+++ b/db/sql/mapper.php
@@ -100,10 +100,11 @@ class Mapper extends \DB\Cursor {
 				$this->fields[$key]['changed']=TRUE;
 			return $this->fields[$key]['value']=$val;
 		}
-		// Parenthesize expression in case it's a subquery
+		// adjust result on existing expressions
 		if (isset($this->adhoc[$key]))
 			$this->adhoc[$key]['value']=$val;
 		else
+			// Parenthesize expression in case it's a subquery
 			$this->adhoc[$key]=array('expr'=>'('.$val.')','value'=>NULL);
 		return $val;
 	}
@@ -194,7 +195,7 @@ class Mapper extends \DB\Cursor {
 
 	/**
 	*	Build query string and execute
-	*	@return array
+	*	@return \DB\SQL\Mapper[]
 	*	@param $fields string
 	*	@param $filter string|array
 	*	@param $options array
@@ -298,7 +299,7 @@ class Mapper extends \DB\Cursor {
 
 	/**
 	*	Return records that match criteria
-	*	@return array
+	*	@return \DB\SQL\Mapper[]
 	*	@param $filter string|array
 	*	@param $options array
 	*	@param $ttl int


### PR DESCRIPTION
With this improved type hints, you can get autocompletion on collections (arrays that contain a specific type of objects), if your IDE supports the recommended way of from phpDoc http://phpdoc.org/docs/latest/references/phpdoc/types.html#arrays

![screenshot-2015-04-19-18 51 50](https://cloud.githubusercontent.com/assets/1177647/7220479/863ffe96-e6c8-11e4-9a70-b0e70528abb2.jpg)
