### PR TITLE
SQL Session: custom callback for suspect sessions

### DIFF
--- a/db/sql/session.php
+++ b/db/sql/session.php
@@ -143,8 +143,9 @@ class Session extends Mapper {
 	*	@param $db object
 	*	@param $table string
 	*	@param $force bool
+	*	@param $onsuspect callback
 	**/
-	function __construct(\DB\SQL $db,$table='sessions',$force=TRUE) {
+	function __construct(\DB\SQL $db,$table='sessions',$force=TRUE,$onsuspect=NULL) {
 		if ($force) {
 			$eol="\n";
 			$tab="\t";
@@ -184,8 +185,12 @@ class Session extends Mapper {
 			($agent=$this->agent()) &&
 			(!isset($headers['User-Agent']) ||
 				$agent!=$headers['User-Agent'])) {
-			session_destroy();
-			$fw->error(403);
+			if (isset($onsuspect))
+				$fw->call($onsuspect,array($this));
+			else {
+				session_destroy();
+				$fw->error(403);
+			}
 		}
 		$csrf=$fw->hash($fw->get('ROOT').$fw->get('BASE')).'.'.
 			$fw->hash(mt_rand());


### PR DESCRIPTION
Hi,
this PR is a suggestion to give more flexibility on treatment of suspect sessions (cf. https://github.com/bcosca/fatfree/issues/762).

Ex:
```php
new \DB\SQL\Session($db,'sessions',TRUE,function($session){
  //suspect session >> do something
});
```

If you like it, I'll tweak the other session handlers as well.