### PR TITLE
Fix for unexpected HIVE values when defining an empty HIVE array

### DIFF
--- a/base.php
+++ b/base.php
@@ -2443,7 +2443,7 @@ class View extends Prefab {
 		$this->level++;
 		$fw=Base::instance();
 		$implicit=false;
-		if (!$hive) {
+		if ($hive === null) {
 			$implicit=true;
 			$hive=$fw->hive();
 		}


### PR DESCRIPTION
This pull requests fixes the unexpected values (the whole default `HIVE`) when defining an empty array as custom `HIVE`.