### PR TITLE
CORS support, bcosca/fatfree#731

### DIFF
--- a/base.php
+++ b/base.php
@@ -1519,7 +1519,7 @@ final class Base extends Prefab implements ArrayAccess {
 			// Unhandled HTTP method
 			header('Allow: '.implode(',',array_unique($allowed)));
 			if ($cors) {
-				header('Access-Control-Allow-Methods: '.implode(',',$allowed));
+				header('Access-Control-Allow-Methods: OPTIONS,'.implode(',',$allowed));
 				if ($cors['headers'])
 					header('Access-Control-Allow-Headers: '.(is_array($cors['headers'])?
 						implode(',',$cors['headers']):$cors['headers']));


### PR DESCRIPTION
This PR goes with https://github.com/bcosca/fatfree/issues/731
It follows the general [CORS flowchart](https://camo.githubusercontent.com/9ea48e5f02e4aaea34dc7f7584ee1bb0680e098e/687474703a2f2f7777772e68746d6c35726f636b732e636f6d2f7374617469632f696d616765732f636f72735f7365727665725f666c6f7763686172742e706e67) as well as some recommendations from https://developer.mozilla.org/en-US/docs/Web/HTTP/Access_control_CORS.

It can be controlled by the following settings:

* **CORS.headers**, string or array, allowed headers
* **CORS.origin**, string or false, the allowed origin host or wildcard
* **CORS.credentials**, bool, if cookies are allowed
* **CORS.expose**, string or array, which headers to expose to the client browser
* **CORS.ttl** int, caching time of the preflight OPTION request, see [addition info](http://stackoverflow.com/questions/23543719/cors-access-control-max-age-is-ignored) why a simple constant should be sufficient here.

The `CORS` defaults disallows everything, so it's just disabled as usual. A simple `CORS.origin = *` would enable basic cross-site request support.