### PR TITLE
don't process empty result sets from SQL routines

### DIFF
--- a/db/sql.php
+++ b/db/sql.php
@@ -199,8 +199,9 @@ class SQL {
 					user_error('PDOStatement: '.$error[2],E_USER_ERROR);
 				}
 				if (preg_match('/^\s*'.
-					'(?:CALL|EXPLAIN|SELECT|PRAGMA|SHOW|RETURNING|EXEC)\b/is',
-					$cmd)) {
+					'(?:EXPLAIN|SELECT|PRAGMA|SHOW|RETURNING)\b/is',$cmd) ||
+					(preg_match('/^\s*(?:CALL|EXEC)\b/is',$cmd) &&
+						$query->columnCount())) {
 					$result=$query->fetchall(\PDO::FETCH_ASSOC);
 					// Work around SQLite quote bug
 					if (preg_match('/sqlite2?/',$this->engine))


### PR DESCRIPTION
fix for bcosca/fatfree#771

An alternative would be to modify the whole if condition to only be `if ($query->columnCount())` but I wasn't sure about false positives and `columnCount()`'s performance. Since this issue only hit CALL and EXEC SQL queries, I simply moved those with along with the count check into an extra condition for now.