### PR TITLE
Update template.php

### DIFF
--- a/template.php
+++ b/template.php
@@ -73,7 +73,7 @@ class Template extends Preview {
 			'<?php '.(isset($attrib['if'])?
 				('if ('.$this->token($attrib['if']).') '):'').
 				('echo $this->render('.
-					(preg_match('/^\{\{(.+?)\}\}$/',$attrib['href'])?
+					(preg_match('/^\{\{(.+?)\}\}/',$attrib['href'])?
 						$this->token($attrib['href']):
 						Base::instance()->stringify($attrib['href'])).','.
 					'$this->mime,'.$hive.'); ?>');


### PR DESCRIPTION
In previous version, I was able to use the include tag this way without error;

```` <include href="{{@temp_base}}.{{@section}}.'header.html'" /> ````

after updating to the latest version, I received

``` 500 Internal Server Error ```, in the trace, I saw ```` {{@temp_base}}.{{@section}}.'header.html' not found ````.

it only accepts

```` <include href="{{@temp_base}}.{{@section}}.{{@header_file}}" /> ````
 
I checked through the file history and I noticed the change was added as `` Teak Regex `` on `` March 4, 2015 ``;
```` preg_match('/^\{\{(.+?)\}\}$/',$attrib['href']) ```` which restricts the ``` href ``` value to declared variables or strings only, mixture not allowed.

This little fix save me from the error by allowing mix value in the href attribute of the include tag.