### PR TITLE
Preview/Template/View: added the `$this->f3` property discussed in #50

### DIFF
--- a/base.php
+++ b/base.php
@@ -2425,6 +2425,8 @@ class Cache extends Prefab {
 class View extends Prefab {
 
 	protected
+		//! Fat-Free Framework
+		$f3,
 		//! Template file
 		$view,
 		//! post-rendering handler
@@ -2432,13 +2434,17 @@ class View extends Prefab {
 		//! Nesting level
 		$level=0;
 
+	function __construct() {
+		$this->f3 = Base::instance();
+	}
+
 	/**
 	*	Encode characters to equivalent HTML entities
 	*	@return string
 	*	@param $arg mixed
 	**/
 	function esc($arg) {
-		$fw=Base::instance();
+		$fw=$this->f3;
 		return $fw->recursive($arg,
 			function($val) use($fw) {
 				return is_string($val)?$fw->encode($val):$val;
@@ -2452,7 +2458,7 @@ class View extends Prefab {
 	*	@param $arg mixed
 	**/
 	function raw($arg) {
-		$fw=Base::instance();
+		$fw=$this->f3;
 		return $fw->recursive($arg,
 			function($val) use($fw) {
 				return is_string($val)?$fw->decode($val):$val;
@@ -2467,7 +2473,7 @@ class View extends Prefab {
 	**/
 	protected function sandbox(array $hive=NULL) {
 		$this->level++;
-		$fw=Base::instance();
+		$fw=$this->f3;
 		$implicit=false;
 		if ($hive === null) {
 			$implicit=true;
@@ -2497,7 +2503,7 @@ class View extends Prefab {
 	*	@param $ttl int
 	**/
 	function render($file,$mime='text/html',array $hive=NULL,$ttl=0) {
-		$fw=Base::instance();
+		$fw=$this->f3;
 		$cache=Cache::instance();
 		$cached=$cache->exists($hash=$fw->hash($file),$data);
 		if ($cached && $cached[0]+$ttl>microtime(TRUE))
@@ -2541,8 +2547,8 @@ class Preview extends View {
 		$filter = array(
 			'esc'=>'$this->esc',
 			'raw'=>'$this->raw',
-			'alias'=>'\Base::instance()->alias',
-			'format'=>'\Base::instance()->format'
+			'alias'=>'$this->f3->alias',
+			'format'=>'$this->f3->format'
 		);
 
 	/**
@@ -2552,7 +2558,7 @@ class Preview extends View {
 	**/
 	function token($str) {
 		return trim(preg_replace('/\{\{(.+?)\}\}/s',trim('\1'),
-			Base::instance()->compile($str)));
+			$this->f3->compile($str)));
 	}
 
 	/**
@@ -2585,7 +2591,7 @@ class Preview extends View {
 				if (preg_match('/^([^|]+?)\h*\|(\h*\w+(?:\h*[,;]\h*\w+)*)/',
 					$str,$parts)) {
 					$str=$parts[1];
-					foreach (Base::instance()->split($parts[2]) as $func)
+					foreach ($this->f3->split($parts[2]) as $func)
 						$str=$self->filter($func).'('.$str.')';
 				}
 				return '<?php echo '.$str.'; ?>'.
@@ -2609,7 +2615,7 @@ class Preview extends View {
 	**/
 	function resolve($str,array $hive=NULL) {
 		if (!$hive)
-			$hive=\Base::instance()->hive();
+			$hive=$this->f3->hive();
 		extract($hive);
 		ob_start();
 		eval(' ?>'.$this->build($str).'<?php ');
@@ -2625,7 +2631,7 @@ class Preview extends View {
 	*	@param $ttl int
 	**/
 	function render($file,$mime='text/html',array $hive=NULL,$ttl=0) {
-		$fw=Base::instance();
+		$fw=$this->f3;
 		$cache=Cache::instance();
 		if (!is_dir($tmp=$fw->get('TEMP')))
 			mkdir($tmp,Base::MODE,TRUE);

--- a/template.php
+++ b/template.php
@@ -346,6 +346,7 @@ class Template extends Preview {
 	*	return object
 	**/
 	function __construct() {
+		parent::__construct();
 		$ref=new ReflectionClass(__CLASS__);
 		$this->tags='';
 		foreach ($ref->getmethods() as $method)


### PR DESCRIPTION
This patch adds the `View->f3` property discussed in https://github.com/bcosca/fatfree-core/pull/50.
It passes the `View` and `Template` unit tests and is a better alternative than escaping and cloning the whole `Base` object (repeatedly) by defining `Base::instance()->set('f3', Base::instance());` or `$customHive = ['f3' => Base::instance(), /* … */]`.
Also it's compatible with `PHP 5.3`, which [isn't able to escape and clone objects](http://fatfreeframework.com/base#recursive).
Please keep in mind that only accessible non-static properties are escaped with `PHP >= 5.4` and that `Base->$hive` is a private property.

As we aren't interested in escaping and cloning the `Base` instance to use its methods, we shouldn't escape and clone it.

I'm not satisfied by this patch and would recommend to use `Base::instance()` instead of `$this->f3`, but it could be useful for others:

* https://github.com/bcosca/fatfree-core/pull/50#issuecomment-94781039
* https://github.com/bcosca/fatfree-core/pull/50#issuecomment-94674124

Now it's your turn to decide the fate of this pull request. Have fun!