### PR TITLE
TZ detection with date_default_timezone_get()

### DIFF
--- a/base.php
+++ b/base.php
@@ -2134,7 +2134,7 @@ final class Base extends Prefab implements ArrayAccess {
 			'SERIALIZER'=>extension_loaded($ext='igbinary')?$ext:'php',
 			'TEMP'=>'tmp/',
 			'TIME'=>microtime(TRUE),
-			'TZ'=>(@ini_get('date.timezone'))?:'UTC',
+			'TZ'=>@date_default_timezone_get(),
 			'UI'=>'./',
 			'UNLOAD'=>NULL,
 			'UPLOADS'=>'./',

--- a/base.php
+++ b/base.php
@@ -2134,7 +2134,7 @@ final class Base extends Prefab implements ArrayAccess {
 			'SERIALIZER'=>extension_loaded($ext='igbinary')?$ext:'php',
 			'TEMP'=>'tmp/',
 			'TIME'=>microtime(TRUE),
-			'TZ'=>@date_default_timezone_get(),
+			'TZ'=>date_default_timezone_get(),
 			'UI'=>'./',
 			'UNLOAD'=>NULL,
 			'UPLOADS'=>'./',


### PR DESCRIPTION
This PR implements https://github.com/bcosca/fatfree-core/issues/68. The `@` suppresses the warning which occurs when `PHP < 5.4` fails to guess a time zone.