### PR TITLE
Added support for {@token} syntax in route definition

### DIFF
--- a/base.php
+++ b/base.php
@@ -1369,7 +1369,7 @@ final class Base extends Prefab implements ArrayAccess {
 			$url=$this->rel($this->hive['URI']);
 		$case=$this->hive['CASELESS']?'i':'';
 		preg_match('/^'.
-			preg_replace('/@(\w+\b)/','(?P<\1>[^\/\?]+)',
+			preg_replace('/((\\\{\\\{)?@(\w+\b)(?(2)\\\}\\\}))/','(?P<\3>[^\/\?]+)',
 			str_replace('\*','([^\?]+)',preg_quote($pattern,'/'))).
 				'\/?(?:\?.*)?$/'.$case.'um',$url,$args);
 		return $args;
@@ -1437,10 +1437,10 @@ final class Base extends Prefab implements ArrayAccess {
 						implode(',',$cors['expose']):$cors['expose']));
 				if (is_string($handler)) {
 					// Replace route pattern tokens in handler if any
-					$handler=preg_replace_callback('/({)?@(\w+\b)(?(1)})/',
+					$handler=preg_replace_callback('/({{)?@(\w+\b)(?(1)}})/',
 						function($id) use($args) {
-							$tokid=count($id)>2?2:1;
-							return isset($args[$id[$tokid]])?$args[$id[$tokid]]:$id[0];
+                            $pid=count($id)>2?2:1;
+							return isset($args[$id[$pid]])?$args[$id[$pid]]:$id[0];
 						},
 						$handler
 					);

--- a/base.php
+++ b/base.php
@@ -1439,8 +1439,8 @@ final class Base extends Prefab implements ArrayAccess {
 					// Replace route pattern tokens in handler if any
 					$handler=preg_replace_callback('/({{)?@(\w+\b)(?(1)}})/',
 						function($id) use($args) {
-                            $pid=count($id)>2?2:1;
-							return isset($args[$id[$pid]])?$args[$id[$pid]]:$id[0];
+							$tokid=count($id)>2?2:1;
+							return isset($args[$id[$tokid]])?$args[$id[$tokid]]:$id[0];
 						},
 						$handler
 					);

--- a/base.php
+++ b/base.php
@@ -1437,12 +1437,13 @@ final class Base extends Prefab implements ArrayAccess {
 						implode(',',$cors['expose']):$cors['expose']));
 				if (is_string($handler)) {
 					// Replace route pattern tokens in handler if any
-					$handler=preg_replace_callback('/@(\w+\b)/',
-						function($id) use($args) {
-							return isset($args[$id[1]])?$args[$id[1]]:$id[0];
-						},
-						$handler
-					);
+                    $handler=preg_replace_callback('/({)?@(\w+\b)(?(1)})/',
+                        function($id) use($args) {
+                            $tokid=count($id)>2?2:1;
+                            return isset($args[$id[$tokid]])?$args[$id[$tokid]]:$id[0];
+                        },
+                        $handler
+                    );
 					if (preg_match('/(.+)\h*(?:->|::)/',$handler,$match) &&
 						!class_exists($match[1]))
 						$this->error(404);

--- a/base.php
+++ b/base.php
@@ -1437,13 +1437,13 @@ final class Base extends Prefab implements ArrayAccess {
 						implode(',',$cors['expose']):$cors['expose']));
 				if (is_string($handler)) {
 					// Replace route pattern tokens in handler if any
-                    $handler=preg_replace_callback('/({)?@(\w+\b)(?(1)})/',
-                        function($id) use($args) {
-                            $tokid=count($id)>2?2:1;
-                            return isset($args[$id[$tokid]])?$args[$id[$tokid]]:$id[0];
-                        },
-                        $handler
-                    );
+					$handler=preg_replace_callback('/({)?@(\w+\b)(?(1)})/',
+						function($id) use($args) {
+							$tokid=count($id)>2?2:1;
+							return isset($args[$id[$tokid]])?$args[$id[$tokid]]:$id[0];
+						},
+						$handler
+					);
 					if (preg_match('/(.+)\h*(?:->|::)/',$handler,$match) &&
 						!class_exists($match[1]))
 						$this->error(404);


### PR DESCRIPTION
It allows to handle routes like these (line 2-3):
```
GET /=app\controllers\IndexController->index
GET /account/@action=app\controllers\AccountController->{@action}Action
GET /account/@action/*=app\controllers\AccountController->{@action}Action
GET /account_operation/@action=app\controllers\Account\OperationController->@action
GET /account_operation/@action/*=app\controllers\Account\OperationController->@action
```
which enables you to add prefix or suffix to the tokens found in the URL in order to generate the final handler method (or class, etc.).
**I needed this more importantly to "hide" public methods of the controllers that I didn't want to be reached by URL.** (in my case, only methods ending in "Action" can be called)

If it's not necessary because of some other cool feature that I didn't know about, I'd be glad to learn :)