### PR TITLE
Escape regex characters in customizable Base->extract() prefixes

### DIFF
--- a/base.php
+++ b/base.php
@@ -687,7 +687,7 @@ final class Base extends Prefab implements ArrayAccess {
 	**/
 	function extract($arr,$prefix) {
 		$out=array();
-		foreach (preg_grep('/^'.$prefix.'/',array_keys($arr)) as $key)
+		foreach (preg_grep('/^'.preg_quote($prefix,'/').'/',array_keys($arr)) as $key)
 			$out[substr($key,strlen($prefix))]=$arr[$key];
 		return $out;
 	}


### PR DESCRIPTION
This PR fixes unexpected values (see example below) and `preg_grep(): Unknown modifier '/'` errors when working with `Base->extract()`.

**Example**

```
$data = ['app.version' => 42, 'apps' => []];
$prefix = 'app.';
var_dump(Base::instance()->extract($data, $prefix));
```

**Expected/PR**

```
array(1) {
  ["version"]=>
  int(42)
}
```

**Not expected**

```
array(2) {
  ["version"]=>
  int(42)
  [0]=>
  array(0) {
  }
}
```
