### PR TITLE
improved Template parsing

### DIFF
--- a/template.php
+++ b/template.php
@@ -269,24 +269,24 @@ class Template extends Preview {
 	**/
 	function parse($text) {
 		// Build tree structure
-		for ($ptr=0,$len=strlen($text),$tree=array(),$tmp='';$ptr<$len;)
-			if (preg_match('/^<(\/?)(?:F3:)?'.
+		for ($ptr=0,$w=5,$len=strlen($text),$tree=array(),$tmp='';$ptr<$len;)
+			if (preg_match('/^(.{0,'.$w.'}?)<(\/?)(?:F3:)?'.
 				'('.$this->tags.')\b((?:\h+[\w-]+'.
 				'(?:\h*=\h*(?:"(?:.*?)"|\'(?:.*?)\'))?|'.
 				'\h*\{\{.+?\}\})*)\h*(\/?)>/is',
 				substr($text,$ptr),$match)) {
-				if (strlen($tmp))
-					$tree[]=$tmp;
+				if (strlen($tmp)||$match[1])
+					$tree[]=$tmp.$match[1];
 				// Element node
-				if ($match[1]) {
+				if ($match[2]) {
 					// Find matching start tag
 					$stack=array();
 					for($i=count($tree)-1;$i>=0;$i--) {
 						$item = $tree[$i];
-						if (is_array($item) && array_key_exists($match[2],$item)
-						&& !isset($item[$match[2]][0])) {
+						if (is_array($item) && array_key_exists($match[3],$item)
+						&& !isset($item[$match[3]][0])) {
 							// Start tag found
-							$tree[$i][$match[2]]+=array_reverse($stack);
+							$tree[$i][$match[3]]+=array_reverse($stack);
 							$tree=array_slice($tree,0,$i+1);
 							break;
 						} else $stack[]=$item;
@@ -294,15 +294,15 @@ class Template extends Preview {
 				}
 				else {
 					// Start tag
-					$node=&$tree[][$match[2]];
+					$node=&$tree[][$match[3]];
 					$node=array();
-					if ($match[3]) {
+					if ($match[4]) {
 						// Process attributes
 						preg_match_all(
 							'/(?:\b([\w-]+)\h*'.
 							'(?:=\h*(?:"(.*?)"|\'(.*?)\'))?|'.
 							'(\{\{.+?\}\}))/s',
-							$match[3],$attr,PREG_SET_ORDER);
+							$match[4],$attr,PREG_SET_ORDER);
 						foreach ($attr as $kv)
 							if (isset($kv[4]))
 								$node['@attrib'][]=$kv[4];
@@ -319,8 +319,8 @@ class Template extends Preview {
 			}
 			else {
 				// Text node
-				$tmp.=substr($text,$ptr,1);
-				$ptr++;
+				$tmp.=substr($text,$ptr,$w);
+				$ptr+=$w;
 			}
 		if (strlen($tmp))
 			// Append trailing text

--- a/template.php
+++ b/template.php
@@ -316,11 +316,14 @@ class Template extends Preview {
 				}
 				$tmp='';
 				$ptr+=strlen($match[0]);
+				$w=5;
 			}
 			else {
 				// Text node
 				$tmp.=substr($text,$ptr,$w);
 				$ptr+=$w;
+				if ($w<50)
+					$w++;
 			}
 		if (strlen($tmp))
 			// Append trailing text

--- a/template.php
+++ b/template.php
@@ -280,15 +280,16 @@ class Template extends Preview {
 				// Element node
 				if ($match[1]) {
 					// Find matching start tag
-					for($i=count($tree)-2;$i>=0;$i--) {
+					$stack=array();
+					for($i=count($tree)-1;$i>=0;$i--) {
 						$item = $tree[$i];
 						if (is_array($item) && array_key_exists($match[2],$item)
 						&& !isset($item[$match[2]][0])) {
 							// Start tag found
-							$tree[$i][$match[2]]+=array_slice($tree,$i+1);
+							$tree[$i][$match[2]]+=array_reverse($stack);
 							$tree=array_slice($tree,0,$i+1);
 							break;
-						}
+						} else $stack[]=$item;
 					}
 				}
 				else {


### PR DESCRIPTION
#### It's up to **10x** faster now :laughing: 
The solution for #75 worked so far, but I worked on the parse method to make it needless to set flags for empty tags. As describes in here https://github.com/bcosca/fatfree-core/issues/75#issuecomment-131055889 it now uses a reverse way for tree depths building on closing tags, instead of increasing the tree growth on starting tags.
I also found a way to add chunked-parsing of the template string, which increases the total parsing speed as well :D for a little benchmark I looped the parsing of my [fooforms template](https://github.com/ikkez/F3-Sugar/blob/master-v3/FooForms/ui/templates/fooforms.html) which contains dozens of different handled tag elements.
```php
$file = $f3->read('ui/templates/fooforms.html');
$start = microtime(TRUE);
for ($i = 0,$max = 10;$i<$max;$i++)
	\Template::instance()->parse($file);
$end = microtime(TRUE);
echo "time: ".round(1e3*($end-$start),2)."ms,  '.
  'memory: ".round(memory_get_usage(TRUE)/1e3,1)."\n";
```
results [current](https://github.com/bcosca/fatfree-core/blob/c71683bb6b24d2fcce41f2c9f0b2b9c6e84a965e/template.php) solution:
```
time: 1666,97ms,  memory: 1572,9kb
```
with [5-chunked](https://github.com/bcosca/fatfree-core/commit/d9d5de81f7e701dfc7fe40fd273fc0ed55ddf872) parsing:
```
time: 369,09ms,  memory: 1572,9kb
```
with [adaptive-chunked](https://github.com/bcosca/fatfree-core/commit/a6cdae2b101aaf0701ca098b40b7151b9c9d23c7) parsing;
```
time: 158,79ms,  memory: 1572,9kb
```