### PR TITLE
Revert "Added support for {@token} syntax in route definition"

### DIFF
--- a/base.php
+++ b/base.php
@@ -1375,7 +1375,7 @@ final class Base extends Prefab implements ArrayAccess {
 			$url=$this->rel($this->hive['URI']);
 		$case=$this->hive['CASELESS']?'i':'';
 		preg_match('/^'.
-			preg_replace('/((\\\{\\\{)?@(\w+\b)(?(2)\\\}\\\}))/','(?P<\3>[^\/\?]+)',
+			preg_replace('/@(\w+\b)/','(?P<\1>[^\/\?]+)',
 			str_replace('\*','([^\?]+)',preg_quote($pattern,'/'))).
 				'\/?(?:\?.*)?$/'.$case.'um',$url,$args);
 		return $args;
@@ -1443,10 +1443,9 @@ final class Base extends Prefab implements ArrayAccess {
 						implode(',',$cors['expose']):$cors['expose']));
 				if (is_string($handler)) {
 					// Replace route pattern tokens in handler if any
-					$handler=preg_replace_callback('/({{)?@(\w+\b)(?(1)}})/',
+					$handler=preg_replace_callback('/@(\w+\b)/',
 						function($id) use($args) {
-							$tokid=count($id)>2?2:1;
-							return isset($args[$id[$tokid]])?$args[$id[$tokid]]:$id[0];
+							return isset($args[$id[1]])?$args[$id[1]]:$id[0];
 						},
 						$handler
 					);


### PR DESCRIPTION
Reverts bcosca/fatfree-core#72

I see that the merge was for a double brace syntax, which everyone agreed was a bit troublesome. Reverting and waiting for a proper PR.