### PR TITLE
resolve filters within token method

### DIFF
--- a/base.php
+++ b/base.php
@@ -2561,7 +2561,7 @@ class Preview extends View {
 	*	@param $str string
 	**/
 	function token($str) {
-		$str = trim(preg_replace('/\{\{(.+?)\}\}/s',trim('\1'),
+		$str=trim(preg_replace('/\{\{(.+?)\}\}/s',trim('\1'),
 			Base::instance()->compile($str)));
 		if (preg_match('/^([^|]+?)\h*\|(\h*\w+(?:\h*[,;]\h*\w+)*)/',
 			$str,$parts)) {

--- a/base.php
+++ b/base.php
@@ -2561,8 +2561,15 @@ class Preview extends View {
 	*	@param $str string
 	**/
 	function token($str) {
-		return trim(preg_replace('/\{\{(.+?)\}\}/s',trim('\1'),
+		$str = trim(preg_replace('/\{\{(.+?)\}\}/s',trim('\1'),
 			Base::instance()->compile($str)));
+		if (preg_match('/^([^|]+?)\h*\|(\h*\w+(?:\h*[,;]\h*\w+)*)/',
+			$str,$parts)) {
+			$str=$parts[1];
+			foreach (Base::instance()->split($parts[2]) as $func)
+				$str=$this->filter($func).'('.$str.')';
+		}
+		return $str;
 	}
 
 	/**
@@ -2592,12 +2599,6 @@ class Preview extends View {
 				if ($expr[1])
 					return $expr[1];
 				$str=trim($self->token($expr[2]));
-				if (preg_match('/^([^|]+?)\h*\|(\h*\w+(?:\h*[,;]\h*\w+)*)/',
-					$str,$parts)) {
-					$str=$parts[1];
-					foreach (Base::instance()->split($parts[2]) as $func)
-						$str=$self->filter($func).'('.$str.')';
-				}
 				return empty($expr[4])?
 					('<?php echo '.$str.'; ?>'.
 					(isset($expr[3])?$expr[3]."\n":'')):


### PR DESCRIPTION
I just moved the part for resolving the token filters into the token method itself. This improves support for token filters within custom tag handlers and existing template directives, like:
```html
<repeat group="{{ @myArray, 'even' | pick }}" value="{{@item}}">
```
This should be harmless to merge. Thx @ coder142 from IRC, how gave a hint about that.