### PR TITLE
allow anonymous function for template filter

### DIFF
--- a/base.php
+++ b/base.php
@@ -2569,7 +2569,10 @@ class Preview extends View {
 			$str,$parts)) {
 			$str=trim($parts[1]);
 			foreach (Base::instance()->split($parts[2]) as $func)
-				$str=$this->filter($func).'('.$str.')';
+				$str=is_callable($cmd=$this->filter($func))
+					?'\Base::instance()->call('.
+						'$this->filter(\''.$func.'\'),array('.$str.'))'
+					:$cmd.'('.$str.')';
 		}
 		return $str;
 	}


### PR DESCRIPTION
Regarding bcosca/fatfree#872, I thought it would be good to allow anonymous filters.

```php
\Template::instance()->filter('rev',function($val){
	return strrev($val);
});
```

Anonymous functions are already possible for *Template->extend* too, so this could make both usages more even. I'm just still indecisive with the implementation, cause you would need to clear your template-cache when you change your filter definition from string to callback. On the other hand we probably want to keep it simple and not outsource too much logic into the template. Thoughts?