### PR TITLE
Bug fix: Cursor->load not always mapping to first record

### DIFF
--- a/db/cursor.php
+++ b/db/cursor.php
@@ -171,8 +171,9 @@ abstract class Cursor extends \Magic implements \IteratorAggregate {
 	*	@param $ttl int
 	**/
 	function load($filter=NULL,array $options=NULL,$ttl=0) {
+		$this->ptr=0;
 		return ($this->query=$this->find($filter,$options,$ttl)) &&
-			$this->skip(0)?$this->query[$this->ptr=0]:FALSE;
+			$this->skip(0)?$this->query[$this->ptr]:FALSE;
 	}
 
 	/**


### PR DESCRIPTION
This bug arises when using multiple `load()` on the same mapper:
```php
$mapper->load('');//10 records
$mapper->last();//ptr=9
echo $mapper->dry()?'ERR':'OK';// output: OK
$mapper->load('tag=6');//1 record found but ptr=9 doesn't map
echo $mapper->dry()?'ERR':'OK';// output: ERR
```

The reason of this bug is that `$this->skip(0)` is called before the pointer is reset.