### PR TITLE
Map copyfrom() to set()

### DIFF
--- a/basket.php
+++ b/basket.php
@@ -195,7 +195,7 @@ class Basket extends Magic {
 		if (is_string($var))
 			$var=\Base::instance()->get($var);
 		foreach ($var as $key=>$val)
-			$this->item[$key]=$val;
+			$this->set($key,$val);
 	}
 
 	/**

--- a/db/jig/mapper.php
+++ b/db/jig/mapper.php
@@ -431,7 +431,7 @@ class Mapper extends \DB\Cursor {
 		if ($func)
 			$var=call_user_func($func,$var);
 		foreach ($var as $key=>$val)
-			$this->document[$key]=$val;
+			$this->set($key,$val);
 	}
 
 	/**

--- a/db/mongo/mapper.php
+++ b/db/mongo/mapper.php
@@ -308,7 +308,7 @@ class Mapper extends \DB\Cursor {
 		if ($func)
 			$var=call_user_func($func,$var);
 		foreach ($var as $key=>$val)
-			$this->document[$key]=$val;
+			$this->set($key,$val);
 	}
 
 	/**

--- a/db/sql/mapper.php
+++ b/db/sql/mapper.php
@@ -559,14 +559,8 @@ class Mapper extends \DB\Cursor {
 		if ($func)
 			$var=call_user_func($func,$var);
 		foreach ($var as $key=>$val)
-			if (in_array($key,array_keys($this->fields))) {
-				$field=&$this->fields[$key];
-				if ($field['value']!==$val) {
-					$field['value']=$val;
-					$field['changed']=TRUE;
-				}
-				unset($field);
-			}
+			if (in_array($key,array_keys($this->fields)))
+				$this->set($key,$val);
 	}
 
 	/**


### PR DESCRIPTION
Here is a proposal to have all `copyfrom()` methods internally call their sibling `set()` method, so that we keep control of the setter logic in one same place.

This is especially useful for the SQL mapper where the logic inside `copyfrom()` is not as refined as the one in `set()`.