### PR TITLE
add referenced value to devoid method

### DIFF
--- a/base.php
+++ b/base.php
@@ -305,10 +305,11 @@ final class Base extends Prefab implements ArrayAccess {
 
 	/**
 	*	Return TRUE if hive key is empty and not cached
-	*	@return bool
 	*	@param $key string
+	*	@param $val mixed
+	*	@return bool
 	**/
-	function devoid($key) {
+	function devoid($key,&$val=NULL) {
 		$val=$this->ref($key,FALSE);
 		return empty($val) &&
 			(!Cache::instance()->exists($this->hash($key).'.var',$val) ||


### PR DESCRIPTION
Would be nice if we can add the referenced value from the key checked in the `devoid()` method like we already have it for `exists()`.

This is useful when validation form fields, which are often send, but are still empty. A simple exists isn't always enough here:
```php
//  most times we need to check for emptiness
if ($f3->exists('POST.email',$email) && !empty($email))
	echo $email;
// or use deviod
if (!$f3->devoid('POST.email'))
	echo $f3->get('POST.email'); // but now we're starting to repeat ourself
```

Now it's simply:
```php
if (!$f3->devoid('POST.email',$email))
	echo $email;
```