### PR TITLE
DB-managed sessions autostart

### DIFF
--- a/base.php
+++ b/base.php
@@ -423,8 +423,7 @@ final class Base extends Prefab implements ArrayAccess {
 				// End session
 				session_unset();
 				session_destroy();
-				unset($_COOKIE[session_name()]);
-				header_remove('Set-Cookie');
+				$this->clear('COOKIE.'.session_name());
 			}
 			$this->sync('SESSION');
 		}

--- a/db/sql/session.php
+++ b/db/sql/session.php
@@ -27,7 +27,15 @@ class Session extends Mapper {
 
 	protected
 		//! Session ID
-		$sid;
+		$sid,
+		//! Anti-CSRF token
+		$_csrf,
+		//! User agent
+		$_agent,
+		//! IP,
+		$_ip,
+		//! Suspect callback
+		$onsuspect;
 
 	/**
 	*	Open session
@@ -44,6 +52,8 @@ class Session extends Mapper {
 	*	@return TRUE
 	**/
 	function close() {
+		$this->reset();
+		$this->sid=NULL;
 		return TRUE;
 	}
 
@@ -53,8 +63,20 @@ class Session extends Mapper {
 	*	@param $id string
 	**/
 	function read($id) {
-		if ($id!=$this->sid)
-			$this->load(array('session_id=?',$this->sid=$id));
+		$this->load(array('session_id=?',$this->sid=$id));
+		$fw=\Base::instance();
+		if (($ip=$this->get('ip')) && $ip!=$this->_ip ||
+			($agent=$this->get('agent')) && $agent!=$this->_agent ||
+			($csrf=$fw->get('POST.csrf')) && $csrf!=$this->get('csrf')) {
+			if (!isset($this->onsuspect) ||
+				FALSE===$fw->call($this->onsuspect,array($this,$id))) {
+				//NB: `session_destroy` can't be called at that stage (`session_start` not completed)
+				$this->destroy($id);
+				$this->close();
+				$fw->clear('COOKIE.'.session_name());
+				$fw->error(403);
+			}
+		}
 		return $this->dry()?FALSE:$this->get('data');
 	}
 
@@ -65,19 +87,11 @@ class Session extends Mapper {
 	*	@param $data string
 	**/
 	function write($id,$data) {
-		$fw=\Base::instance();
-		$sent=headers_sent();
-		$headers=$fw->get('HEADERS');
-		if ($id!=$this->sid)
-			$this->load(array('session_id=?',$this->sid=$id));
-		$csrf=$fw->hash($fw->get('ROOT').$fw->get('BASE')).'.'.
-			$fw->hash(mt_rand());
 		$this->set('session_id',$id);
 		$this->set('data',$data);
-		$this->set('csrf',$sent?$this->csrf():$csrf);
-		$this->set('ip',$fw->get('IP'));
-		$this->set('agent',
-			isset($headers['User-Agent'])?$headers['User-Agent']:'');
+		$this->set('csrf',$this->_csrf);
+		$this->set('ip',$this->_ip);
+		$this->set('agent',$this->_agent);
 		$this->set('stamp',time());
 		$this->save();
 		return TRUE;
@@ -90,9 +104,6 @@ class Session extends Mapper {
 	**/
 	function destroy($id) {
 		$this->erase(array('session_id=?',$id));
-		setcookie(session_name(),'',strtotime('-1 year'));
-		unset($_COOKIE[session_name()]);
-		header_remove('Set-Cookie');
 		return TRUE;
 	}
 
@@ -107,19 +118,27 @@ class Session extends Mapper {
 	}
 
 	/**
+	*	Return session id (if session has started)
+	*	@return string|NULL
+	**/
+	function sid() {
+		return $this->sid;
+	}
+
+	/**
 	*	Return anti-CSRF token
-	*	@return string|FALSE
+	*	@return string
 	**/
 	function csrf() {
-		return $this->dry()?FALSE:$this->get('csrf');
+		return $this->_csrf;
 	}
 
 	/**
 	*	Return IP address
-	*	@return string|FALSE
+	*	@return string
 	**/
 	function ip() {
-		return $this->dry()?FALSE:$this->get('ip');
+		return $this->_ip;
 	}
 
 	/**
@@ -127,20 +146,22 @@ class Session extends Mapper {
 	*	@return string|FALSE
 	**/
 	function stamp() {
+		if (!$this->sid)
+			session_start();
 		return $this->dry()?FALSE:$this->get('stamp');
 	}
 
 	/**
 	*	Return HTTP user agent
-	*	@return string|FALSE
+	*	@return string
 	**/
 	function agent() {
-		return $this->dry()?FALSE:$this->get('agent');
+		return $this->_agent;
 	}
 
 	/**
 	*	Instantiate class
-	*	@param $db object
+	*	@param $db \DB\SQL
 	*	@param $table string
 	*	@param $force bool
 	*	@param $onsuspect callback
@@ -169,6 +190,7 @@ class Session extends Mapper {
 			);
 		}
 		parent::__construct($db,$table);
+		$this->onsuspect=$onsuspect;
 		session_set_save_handler(
 			array($this,'open'),
 			array($this,'close'),
@@ -178,26 +200,12 @@ class Session extends Mapper {
 			array($this,'cleanup')
 		);
 		register_shutdown_function('session_commit');
-		@session_start();
 		$fw=\Base::instance();
 		$headers=$fw->get('HEADERS');
-		if (($ip=$this->ip()) && $ip!=$fw->get('IP') ||
-			($agent=$this->agent()) &&
-			(!isset($headers['User-Agent']) ||
-				$agent!=$headers['User-Agent'])) {
-			if (isset($onsuspect))
-				$fw->call($onsuspect,array($this));
-			else {
-				session_destroy();
-				$fw->error(403);
-			}
-		}
-		$csrf=$fw->hash($fw->get('ROOT').$fw->get('BASE')).'.'.
+		$this->_csrf=$fw->hash($fw->get('ROOT').$fw->get('BASE')).'.'.
 			$fw->hash(mt_rand());
-		if ($this->load(array('session_id=?',$this->sid=session_id()))) {
-			$this->set('csrf',$csrf);
-			$this->save();
-		}
+		$this->_agent=isset($headers['User-Agent'])?$headers['User-Agent']:'';
+		$this->_ip=$fw->get('IP');
 	}
 
 }


### PR DESCRIPTION
This is a followup of #89. The original idea was to move the `session_start` out of the class constructor, in order not to autostart DB-managed sessions.

This change actually required more refactoring that I initially thought.

Here are a few points related to [PHP sessions](http://php.net/manual/en/function.session-set-save-handler.php) to consider:

* `session_start` triggers consecutively the `open` and `read` methods
* `session_write_close` triggers consecutively the `write` and `close` methods
* `session_write_close` is automatically called during the shutdown sequence unless it has been called specifically inside the script
* `session_commit` is an alias for `session_write_close`
* `session_destroy` triggers consecutively the `destroy` and `close` methods
* `session_regenerate_id` doesn't trigger any session class method
* `session_regenerate_id(TRUE)` triggers the `destroy` method only
* nothing prevents a script from calling `session_start` and `session_write_close` several times

Based on this behaviour, this PR suggests to refactor the session class as follows:
* CSRF token, agent string and client IP are computed/fetched in the constructor and written to db by the `write` method.
* suspicious sessions are detected inside `read`.
* the mapper `load()` method is called once, inside `read`. There's no reason to call it from `write`, as `write` should always come after `read`.
* `$sid` contains the session id **only** if the session has been started. So `(bool)$session->sid()` should be equivalent to `session_status()===PHP_SESSION_ACTIVE`, with the difference that it's working in PHP 5.3.

Additionally, I've included two changes in the class behavior which are not directly related to the autostart issue:
* as the `destroy` method is expected to clear the session data, and nothing more, I removed the cookie deletion from it. Since the cookie deletion is a framework feature, I think it better belongs to `$f3->clear('SESSION')`.
* the detection of suspicious sessions include invalid posted anti-CSRF tokens

Those 2 additional changes may not satisfy everybody as they may break backwards compatibility (slight change in `destroy` + anti-CSRF token expected to be transmitted over `POST.csrf`), so I'll wait for general agreement before patching the other session handlers.