### PR TITLE
Fixed TTL of `View` and `Preview` (`Template`)

### DIFF
--- a/base.php
+++ b/base.php
@@ -2532,7 +2532,7 @@ class View extends Prefab {
 					foreach($this->trigger['afterrender'] as $func)
 						$data=$fw->call($func,$data);
 				if ($ttl)
-					$cache->set($hash,$data);
+					$cache->set($hash,$data,$ttl);
 				return $data;
 			}
 		user_error(sprintf(Base::E_Open,$file),E_USER_ERROR);
@@ -2680,7 +2680,7 @@ class Preview extends View {
 					foreach ($this->trigger['afterrender'] as $func)
 						$data = $fw->call($func, $data);
 				if ($ttl)
-					$cache->set($hash,$data);
+					$cache->set($hash,$data,$ttl);
 				return $data;
 			}
 		}


### PR DESCRIPTION
`View` and `Preview` (`Template`) ignore the provided `$ttl` length. They are only caching indefinitely (`(bool) $ttl`) or aren't caching at all.

See also: https://github.com/bcosca/fatfree-core/pull/96#issuecomment-158403805

I'll add unit tests later. Manual tests: [Source](https://gist.github.com/Rayne/cdf579fa3cce78ba1466)