### PR TITLE
Performance improvement: mapper->select() should return a fixed size array

### DIFF
--- a/base.php
+++ b/base.php
@@ -759,6 +759,12 @@ final class Base extends Prefab implements ArrayAccess {
 			$stack=array();
 		switch (gettype($arg)) {
 			case 'object':
+				if($arg instanceof SplFixedArray){
+					$copy=new \SplFixedArray(count($arg));
+					foreach ($arg as $key=>$val)
+						$copy[$key]=$this->recursive($val,$func, array_merge($stack,array($arg)));
+					return $copy;
+				}
 				if (method_exists('ReflectionClass','iscloneable')) {
 					$ref=new ReflectionClass($arg);
 					if ($ref->iscloneable()) {

--- a/db/cursor.php
+++ b/db/cursor.php
@@ -247,6 +247,9 @@ abstract class Cursor extends \Magic implements \IteratorAggregate {
 	*	@return int|bool
 	**/
 	function erase() {
+		if(gettype($this->query)=='object' && get_class($this->query)=='SplFixedArray'){$this->query = $this->query->toArray();}
+		//convert SplFixedArray to primitive array to be able to use array_slice
+		
 		$this->query=array_slice($this->query,0,$this->ptr,TRUE)+
 			array_slice($this->query,$this->ptr,NULL,TRUE);
 		$this->skip(0);

--- a/db/mongo/mapper.php
+++ b/db/mongo/mapper.php
@@ -169,9 +169,17 @@ class Mapper extends \DB\Cursor {
 				// Save to cache backend
 				$cache->set($hash,$result,$ttl);
 		}
-		$out=array();
-		foreach ($result as $doc)
-			$out[]=$this->factory($doc);
+                if(class_exists('SplFixedArray')) {
+                    $out = new \SplFixedArray(count($result));
+                }else{
+                    $out = array();
+                }
+                $c=0;
+                foreach ($result as $doc){
+			$out[$c]=$this->factory($doc);
+                        $c++;
+                }
+                unset($c);
 		return $out;
 	}
 

--- a/db/mongo/mapper.php
+++ b/db/mongo/mapper.php
@@ -169,19 +169,17 @@ class Mapper extends \DB\Cursor {
 				// Save to cache backend
 				$cache->set($hash,$result,$ttl);
 		}
-                if(class_exists('SplFixedArray')) {
-                    $out = new \SplFixedArray(count($result));
-                }else{
-                    $out = array();
-                }
-                $c=0;
-                foreach ($result as $doc){
-			$out[$c]=$this->factory($doc);
-                        $c++;
-                }
-                unset($c);
+		
+		$resultSize = count($result);
+		$out = (class_exists('SplFixedArray') && $resultSize>0) ? new \SplFixedArray($resultSize) : array();
+		//important: empty SplFixedArray should not be created, since empty(new \SplFixedArray(0)) does not return true
+		
+		for($c=0;$c<$resultSize;$c++){
+		    $out[$c]=$this->factory($result[$c]);
+		}
 		return $out;
 	}
+
 
 	/**
 	*	Return records that match criteria

--- a/db/mongo/mapper.php
+++ b/db/mongo/mapper.php
@@ -180,7 +180,6 @@ class Mapper extends \DB\Cursor {
 		return $out;
 	}
 
-
 	/**
 	*	Return records that match criteria
 	*	@return \DB\Mongo\Mapper[]

--- a/db/mongo/mapper.php
+++ b/db/mongo/mapper.php
@@ -175,7 +175,7 @@ class Mapper extends \DB\Cursor {
 		//important: empty SplFixedArray should not be created, since empty(new \SplFixedArray(0)) does not return true
 		
 		for($c=0;$c<$resultSize;$c++){
-		    $out[$c]=$this->factory($result[$c]);
+			$out[$c]=$this->factory($result[$c]);
 		}
 		return $out;
 	}


### PR DESCRIPTION
After patching {mapper.php, cursor.php, base.php} in order to use SplFixedArray rather than array(), there's a ~20% improvement in memory and cpu speed in query heavy pages. 

At first the performance gain appeared more than that, but that's because base.php was ignoring the SplFixedArray in the recursive function for cleaning, i.e., for XSS avoidance. [All items in f3's hive are duplicated in memory in order to apply the cleaning functions!]

I'm fairly confident that all uses of select()'s output (i.e., the SplFixedArray) have been patched to be able to operate on the SplFixedArray (since native array functions don't work). 

If the idea isn't accepted, then at least it served as an experiment to see what advantage there would be. Further optimisation work should be focused on the way that f3 cleans variables before they're printed out by templates (e.g., by instead wrapping all calls to hive variables rather than cleaning all hive variables).