### PR TITLE
Update fatfree-core to use the top level vendor namespace F3. Refs #110

### DIFF
--- a/audit.php
+++ b/audit.php
@@ -20,6 +20,8 @@
 
 */
 
+namespace F3;
+
 //! Data validator
 class Audit extends Prefab {
 

--- a/auth.php
+++ b/auth.php
@@ -20,6 +20,8 @@
 
 */
 
+namespace F3;
+
 
 //! Authorization/authentication plug-in
 class Auth {

--- a/base.php
+++ b/base.php
@@ -20,6 +20,8 @@
 
 */
 
+namespace F3;
+
 //! Factory class for single-instance objects
 abstract class Prefab {
 
@@ -29,7 +31,7 @@ abstract class Prefab {
 	**/
 	static function instance() {
 		if (!Registry::exists($class=get_called_class())) {
-			$ref=new Reflectionclass($class);
+			$ref=new \Reflectionclass($class);
 			$args=func_get_args();
 			Registry::set($class,
 				$args?$ref->newinstanceargs($args):new $class);
@@ -40,7 +42,7 @@ abstract class Prefab {
 }
 
 //! Base structure
-final class Base extends Prefab implements ArrayAccess {
+final class Base extends Prefab implements \ArrayAccess {
 
 	//@{ Framework details
 	const
@@ -460,7 +462,7 @@ final class Base extends Prefab implements ArrayAccess {
 	**/
 	function visible($obj,$key) {
 		if (property_exists($obj,$key)) {
-			$ref=new ReflectionProperty(get_class($obj),$key);
+			$ref=new \ReflectionProperty(get_class($obj),$key);
 			$out=$ref->ispublic();
 			unset($ref);
 			return $out;
@@ -699,7 +701,7 @@ final class Base extends Prefab implements ArrayAccess {
 	*	@param $prefix string
 	**/
 	function constants($class,$prefix='') {
-		$ref=new ReflectionClass($class);
+		$ref=new \ReflectionClass($class);
 		return $this->extract($ref->getconstants(),$prefix);
 	}
 
@@ -760,7 +762,7 @@ final class Base extends Prefab implements ArrayAccess {
 		switch (gettype($arg)) {
 			case 'object':
 				if (method_exists('ReflectionClass','iscloneable')) {
-					$ref=new ReflectionClass($arg);
+					$ref=new \ReflectionClass($arg);
 					if ($ref->iscloneable()) {
 						$arg=clone($arg);
 						$cast=is_a($arg,'IteratorAggregate')?
@@ -1617,7 +1619,7 @@ final class Base extends Prefab implements ArrayAccess {
 				if (is_subclass_of($parts[1],'Prefab'))
 					$parts[1]=call_user_func($parts[1].'::instance');
 				else {
-					$ref=new ReflectionClass($parts[1]);
+					$ref=new \ReflectionClass($parts[1]);
 					$parts[1]=method_exists($parts[1],'__construct')?
 						$ref->newinstanceargs($args):
 						$ref->newinstance();
@@ -1896,7 +1898,7 @@ final class Base extends Prefab implements ArrayAccess {
 				is_file($file=$auto.$class.'.php') ||
 				is_file($file=$auto.strtolower($class).'.php') ||
 				is_file($file=strtolower($auto.$class).'.php'))
-				return require($file);
+				return require_once($file);
 	}
 
 	/**
@@ -2394,7 +2396,7 @@ class Cache extends Prefab {
 					list($host,$port)=$parts;
 				else
 					$host=$parts[0];
-				$this->ref=new Redis;
+				$this->ref=new \Redis;
 				if(!$this->ref->connect($host,$port,2))
 					$this->ref=NULL;
 			}
@@ -2558,8 +2560,8 @@ class Preview extends View {
 		$filter=array(
 			'esc'=>'$this->esc',
 			'raw'=>'$this->raw',
-			'alias'=>'\Base::instance()->alias',
-			'format'=>'\Base::instance()->format'
+			'alias'=>'\F3\Base::instance()->alias',
+			'format'=>'\F3\Base::instance()->format'
 		);
 
 	/**
@@ -2575,7 +2577,7 @@ class Preview extends View {
 			$str=trim($parts[1]);
 			foreach (Base::instance()->split($parts[2]) as $func)
 				$str=is_string($cmd=$this->filter($func))?$cmd.'('.$str.')':
-					'\Base::instance()->call('.
+					'\F3\Base::instance()->call('.
 						'$this->filter(\''.$func.'\'),array('.$str.'))';
 		}
 		return $str;
@@ -2631,7 +2633,7 @@ class Preview extends View {
 	**/
 	function resolve($str,array $hive=NULL) {
 		if (!$hive)
-			$hive=\Base::instance()->hive();
+			$hive=Base::instance()->hive();
 		extract($hive);
 		ob_start();
 		eval(' ?>'.$this->build($str).'<?php ');
@@ -3036,7 +3038,7 @@ class ISO extends Prefab {
 	*	@return array
 	**/
 	function languages() {
-		return \Base::instance()->constants($this,'LC_');
+		return Base::instance()->constants($this,'LC_');
 	}
 
 	/**
@@ -3044,7 +3046,7 @@ class ISO extends Prefab {
 	*	@return array
 	**/
 	function countries() {
-		return \Base::instance()->constants($this,'CC_');
+		return Base::instance()->constants($this,'CC_');
 	}
 
 }

--- a/basket.php
+++ b/basket.php
@@ -20,6 +20,8 @@
 
 */
 
+namespace F3;
+
 //! Session-based pseudo-mapper
 class Basket extends Magic {
 
@@ -193,7 +195,7 @@ class Basket extends Magic {
 	**/
 	function copyfrom($var) {
 		if (is_string($var))
-			$var=\Base::instance()->get($var);
+			$var=Base::instance()->get($var);
 		foreach ($var as $key=>$val)
 			$this->set($key,$val);
 	}
@@ -204,7 +206,7 @@ class Basket extends Magic {
 	*	@param $key string
 	**/
 	function copyto($key) {
-		$var=&\Base::instance()->ref($key);
+		$var=&Base::instance()->ref($key);
 		foreach ($this->item as $key=>$field)
 			$var[$key]=$field;
 	}

--- a/bcrypt.php
+++ b/bcrypt.php
@@ -20,6 +20,8 @@
 
 */
 
+namespace F3;
+
 //! Lightweight password hashing library
 class Bcrypt extends Prefab {
 

--- a/db/cursor.php
+++ b/db/cursor.php
@@ -20,10 +20,10 @@
 
 */
 
-namespace DB;
+namespace F3\DB;
 
 //! Simple cursor implementation
-abstract class Cursor extends \Magic implements \IteratorAggregate {
+abstract class Cursor extends \F3\Magic implements \IteratorAggregate {
 
 	//@{ Error messages
 	const

--- a/db/jig.php
+++ b/db/jig.php
@@ -20,7 +20,7 @@
 
 */
 
-namespace DB;
+namespace F3\DB;
 
 //! In-memory/flat-file DB wrapper
 class Jig {
@@ -54,7 +54,7 @@ class Jig {
 				$this->data[$file]=array();
 			return $this->data[$file];
 		}
-		$fw=\Base::instance();
+		$fw=\F3\Base::instance();
 		$raw=$fw->read($dst);
 		switch ($this->format) {
 			case self::FORMAT_JSON:
@@ -77,7 +77,7 @@ class Jig {
 	function write($file,array $data=NULL) {
 		if (!$this->dir)
 			return count($this->data[$file]=$data);
-		$fw=\Base::instance();
+		$fw=\F3\Base::instance();
 		switch ($this->format) {
 			case self::FORMAT_JSON:
 				$out=json_encode($data,@constant('JSON_PRETTY_PRINT'));
@@ -142,8 +142,8 @@ class Jig {
 	**/
 	function __construct($dir=NULL,$format=self::FORMAT_JSON) {
 		if ($dir && !is_dir($dir))
-			mkdir($dir,\Base::MODE,TRUE);
-		$this->uuid=\Base::instance()->hash($this->dir=$dir);
+			mkdir($dir,\F3\Base::MODE,TRUE);
+		$this->uuid=\F3\Base::instance()->hash($this->dir=$dir);
 		$this->format=$format;
 	}
 

--- a/db/jig/mapper.php
+++ b/db/jig/mapper.php
@@ -20,10 +20,10 @@
 
 */
 
-namespace DB\Jig;
+namespace F3\DB\Jig;
 
 //! Flat-file DB mapper
-class Mapper extends \DB\Cursor {
+class Mapper extends \F3\DB\Cursor {
 
 	protected
 		//! Flat-file DB wrapper
@@ -99,7 +99,7 @@ class Mapper extends \DB\Cursor {
 			$mapper->document[$field]=$val;
 		$mapper->query=array(clone($mapper));
 		if (isset($mapper->trigger['load']))
-			\Base::instance()->call($mapper->trigger['load'],$mapper);
+			\F3\Base::instance()->call($mapper->trigger['load'],$mapper);
 		return $mapper;
 	}
 
@@ -128,7 +128,7 @@ class Mapper extends \DB\Cursor {
 				return '$'.preg_replace_callback(
 					'/(\.\w+)|\[((?:[^\[\]]*|(?R))*)\]/',
 					function($expr) use($self) {
-						$fw=\Base::instance();
+						$fw=\F3\Base::instance();
 						return
 							'['.
 							($expr[1]?
@@ -163,8 +163,8 @@ class Mapper extends \DB\Cursor {
 			'limit'=>0,
 			'offset'=>0
 		);
-		$fw=\Base::instance();
-		$cache=\Cache::instance();
+		$fw=\F3\Base::instance();
+		$cache=\F3\Cache::instance();
 		$db=$this->db;
 		$now=microtime(TRUE);
 		$data=array();
@@ -306,7 +306,7 @@ class Mapper extends \DB\Cursor {
 		$this->document=($out=parent::skip($ofs))?$out->document:array();
 		$this->id=$out?$out->id:NULL;
 		if ($this->document && isset($this->trigger['load']))
-			\Base::instance()->call($this->trigger['load'],$this);
+			\F3\Base::instance()->call($this->trigger['load'],$this);
 		return $out;
 	}
 
@@ -326,7 +326,7 @@ class Mapper extends \DB\Cursor {
 		$this->id=$id;
 		$pkey=array('_id'=>$this->id);
 		if (isset($this->trigger['beforeinsert']) &&
-			\Base::instance()->call($this->trigger['beforeinsert'],
+			\F3\Base::instance()->call($this->trigger['beforeinsert'],
 				array($this,$pkey))===FALSE)
 			return $this->document;
 		$data[$id]=$this->document;
@@ -334,7 +334,7 @@ class Mapper extends \DB\Cursor {
 		$db->jot('('.sprintf('%.1f',1e3*(microtime(TRUE)-$now)).'ms) '.
 			$this->file.' [insert] '.json_encode($this->document));
 		if (isset($this->trigger['afterinsert']))
-			\Base::instance()->call($this->trigger['afterinsert'],
+			\F3\Base::instance()->call($this->trigger['afterinsert'],
 				array($this,$pkey));
 		$this->load(array('@_id=?',$this->id));
 		return $this->document;
@@ -349,7 +349,7 @@ class Mapper extends \DB\Cursor {
 		$now=microtime(TRUE);
 		$data=&$db->read($this->file);
 		if (isset($this->trigger['beforeupdate']) &&
-			\Base::instance()->call($this->trigger['beforeupdate'],
+			\F3\Base::instance()->call($this->trigger['beforeupdate'],
 				array($this,array('_id'=>$this->id)))===FALSE)
 			return $this->document;
 		$data[$this->id]=$this->document;
@@ -357,7 +357,7 @@ class Mapper extends \DB\Cursor {
 		$db->jot('('.sprintf('%.1f',1e3*(microtime(TRUE)-$now)).'ms) '.
 			$this->file.' [update] '.json_encode($this->document));
 		if (isset($this->trigger['afterupdate']))
-			\Base::instance()->call($this->trigger['afterupdate'],
+			\F3\Base::instance()->call($this->trigger['afterupdate'],
 				array($this,array('_id'=>$this->id)));
 		return $this->document;
 	}
@@ -385,7 +385,7 @@ class Mapper extends \DB\Cursor {
 		else
 			return FALSE;
 		if (isset($this->trigger['beforeerase']) &&
-			\Base::instance()->call($this->trigger['beforeerase'],
+			\F3\Base::instance()->call($this->trigger['beforeerase'],
 				array($this,$pkey))===FALSE)
 			return FALSE;
 		$db->write($this->file,$data);
@@ -395,7 +395,7 @@ class Mapper extends \DB\Cursor {
 				array_slice($filter,1,NULL,TRUE);
 			$args=is_array($args)?$args:array(1=>$args);
 			foreach ($args as $key=>$val) {
-				$vals[]=\Base::instance()->
+				$vals[]=\F3\Base::instance()->
 					stringify(is_array($val)?$val[0]:$val);
 				$keys[]='/'.(is_numeric($key)?'\?':preg_quote($key)).'/';
 			}
@@ -404,7 +404,7 @@ class Mapper extends \DB\Cursor {
 			$this->file.' [erase] '.
 			($filter?preg_replace($keys,$vals,$filter[0],1):''));
 		if (isset($this->trigger['aftererase']))
-			\Base::instance()->call($this->trigger['aftererase'],
+			\F3\Base::instance()->call($this->trigger['aftererase'],
 				array($this,$pkey));
 		return TRUE;
 	}
@@ -427,7 +427,7 @@ class Mapper extends \DB\Cursor {
 	**/
 	function copyfrom($var,$func=NULL) {
 		if (is_string($var))
-			$var=\Base::instance()->get($var);
+			$var=\F3\Base::instance()->get($var);
 		if ($func)
 			$var=call_user_func($func,$var);
 		foreach ($var as $key=>$val)
@@ -440,7 +440,7 @@ class Mapper extends \DB\Cursor {
 	*	@param $key string
 	**/
 	function copyto($key) {
-		$var=&\Base::instance()->ref($key);
+		$var=&\F3\Base::instance()->ref($key);
 		foreach ($this->document as $key=>$field)
 			$var[$key]=$field;
 	}
@@ -467,7 +467,7 @@ class Mapper extends \DB\Cursor {
 	*	@param $db object
 	*	@param $file string
 	**/
-	function __construct(\DB\Jig $db,$file) {
+	function __construct(\F3\DB\Jig $db,$file) {
 		$this->db=$db;
 		$this->file=$file;
 		$this->reset();

--- a/db/jig/session.php
+++ b/db/jig/session.php
@@ -20,7 +20,7 @@
 
 */
 
-namespace DB\Jig;
+namespace F3\DB\Jig;
 
 //! Jig-managed session handler
 class Session extends Mapper {
@@ -67,7 +67,7 @@ class Session extends Mapper {
 		if ($this->dry())
 			return FALSE;
 		if ($this->get('ip')!=$this->_ip || $this->get('agent')!=$this->_agent) {
-			$fw=\Base::instance();
+			$fw=\F3\Base::instance();
 			if (!isset($this->onsuspect) || FALSE===$fw->call($this->onsuspect,array($this,$id))) {
 				//NB: `session_destroy` can't be called at that stage (`session_start` not completed)
 				$this->destroy($id);
@@ -159,12 +159,12 @@ class Session extends Mapper {
 
 	/**
 	*	Instantiate class
-	*	@param $db \DB\Jig
+	*	@param $db \F3\DB\Jig
 	*	@param $file string
 	*	@param $onsuspect callback
 	*	@param $key string
 	**/
-	function __construct(\DB\Jig $db,$file='sessions',$onsuspect=NULL,$key=NULL) {
+	function __construct(\F3\DB\Jig $db,$file='sessions',$onsuspect=NULL,$key=NULL) {
 		parent::__construct($db,$file);
 		$this->onsuspect=$onsuspect;
 		session_set_save_handler(
@@ -176,7 +176,7 @@ class Session extends Mapper {
 			array($this,'cleanup')
 		);
 		register_shutdown_function('session_commit');
-		$fw=\Base::instance();
+		$fw=\F3\Base::instance();
 		$headers=$fw->get('HEADERS');
 		$this->_csrf=$fw->hash($fw->get('ROOT').$fw->get('BASE')).'.'.
 			$fw->hash(mt_rand());

--- a/db/mongo.php
+++ b/db/mongo.php
@@ -20,7 +20,7 @@
 
 */
 
-namespace DB;
+namespace F3\DB;
 
 //! MongoDB wrapper
 class Mongo {
@@ -102,7 +102,7 @@ class Mongo {
 	*	@param $options array
 	**/
 	function __construct($dsn,$dbname,array $options=NULL) {
-		$this->uuid=\Base::instance()->hash($this->dsn=$dsn);
+		$this->uuid=\F3\Base::instance()->hash($this->dsn=$dsn);
 		$class=class_exists('\MongoClient')?'\MongoClient':'\Mongo';
 		$this->db=new \MongoDB(new $class($dsn,$options?:array()),$dbname);
 		$this->setprofilinglevel(2);

--- a/db/mongo/mapper.php
+++ b/db/mongo/mapper.php
@@ -20,10 +20,10 @@
 
 */
 
-namespace DB\Mongo;
+namespace F3\DB\Mongo;
 
 //! MongoDB mapper
-class Mapper extends \DB\Cursor {
+class Mapper extends \F3\DB\Cursor {
 
 	protected
 		//! MongoDB wrapper
@@ -94,7 +94,7 @@ class Mapper extends \DB\Cursor {
 			$mapper->document[$key]=$val;
 		$mapper->query=array(clone($mapper));
 		if (isset($mapper->trigger['load']))
-			\Base::instance()->call($mapper->trigger['load'],$mapper);
+			\F3\Base::instance()->call($mapper->trigger['load'],$mapper);
 		return $mapper;
 	}
 
@@ -126,8 +126,8 @@ class Mapper extends \DB\Cursor {
 			'limit'=>0,
 			'offset'=>0
 		);
-		$fw=\Base::instance();
-		$cache=\Cache::instance();
+		$fw=\F3\Base::instance();
+		$cache=\F3\Cache::instance();
 		if (!($cached=$cache->exists($hash=$fw->hash($this->db->dsn().
 			$fw->stringify(array($fields,$filter,$options))).'.mongo',
 			$result)) || !$ttl || $cached[0]+$ttl<microtime(TRUE)) {
@@ -201,8 +201,8 @@ class Mapper extends \DB\Cursor {
 	*	@param $ttl int
 	**/
 	function count($filter=NULL,$ttl=0) {
-		$fw=\Base::instance();
-		$cache=\Cache::instance();
+		$fw=\F3\Base::instance();
+		$cache=\F3\Cache::instance();
 		if (!($cached=$cache->exists($hash=$fw->hash($fw->stringify(
 			array($filter))).'.mongo',$result)) || !$ttl ||
 			$cached[0]+$ttl<microtime(TRUE)) {
@@ -223,7 +223,7 @@ class Mapper extends \DB\Cursor {
 	function skip($ofs=1) {
 		$this->document=($out=parent::skip($ofs))?$out->document:array();
 		if ($this->document && isset($this->trigger['load']))
-			\Base::instance()->call($this->trigger['load'],$this);
+			\F3\Base::instance()->call($this->trigger['load'],$this);
 		return $out;
 	}
 
@@ -235,13 +235,13 @@ class Mapper extends \DB\Cursor {
 		if (isset($this->document['_id']))
 			return $this->update();
 		if (isset($this->trigger['beforeinsert']) &&
-			\Base::instance()->call($this->trigger['beforeinsert'],
+			\F3\Base::instance()->call($this->trigger['beforeinsert'],
 				array($this,array('_id'=>$this->document['_id'])))===FALSE)
 			return $this->document;
 		$this->collection->insert($this->document);
 		$pkey=array('_id'=>$this->document['_id']);
 		if (isset($this->trigger['afterinsert']))
-			\Base::instance()->call($this->trigger['afterinsert'],
+			\F3\Base::instance()->call($this->trigger['afterinsert'],
 				array($this,$pkey));
 		$this->load($pkey);
 		return $this->document;
@@ -254,13 +254,13 @@ class Mapper extends \DB\Cursor {
 	function update() {
 		$pkey=array('_id'=>$this->document['_id']);
 		if (isset($this->trigger['beforeupdate']) &&
-			\Base::instance()->call($this->trigger['beforeupdate'],
+			\F3\Base::instance()->call($this->trigger['beforeupdate'],
 				array($this,$pkey))===FALSE)
 			return $this->document;
 		$this->collection->update(
 			$pkey,$this->document,array('upsert'=>TRUE));
 		if (isset($this->trigger['afterupdate']))
-			\Base::instance()->call($this->trigger['afterupdate'],
+			\F3\Base::instance()->call($this->trigger['afterupdate'],
 				array($this,$pkey));
 		return $this->document;
 	}
@@ -275,14 +275,14 @@ class Mapper extends \DB\Cursor {
 			return $this->collection->remove($filter);
 		$pkey=array('_id'=>$this->document['_id']);
 		if (isset($this->trigger['beforeerase']) &&
-			\Base::instance()->call($this->trigger['beforeerase'],
+			\F3\Base::instance()->call($this->trigger['beforeerase'],
 				array($this,$pkey))===FALSE)
 			return FALSE;
 		$result=$this->collection->
 			remove(array('_id'=>$this->document['_id']));
 		parent::erase();
 		if (isset($this->trigger['aftererase']))
-			\Base::instance()->call($this->trigger['aftererase'],
+			\F3\Base::instance()->call($this->trigger['aftererase'],
 				array($this,$pkey));
 		return $result;
 	}
@@ -304,7 +304,7 @@ class Mapper extends \DB\Cursor {
 	**/
 	function copyfrom($var,$func=NULL) {
 		if (is_string($var))
-			$var=\Base::instance()->get($var);
+			$var=\F3\Base::instance()->get($var);
 		if ($func)
 			$var=call_user_func($func,$var);
 		foreach ($var as $key=>$val)
@@ -317,7 +317,7 @@ class Mapper extends \DB\Cursor {
 	*	@param $key string
 	**/
 	function copyto($key) {
-		$var=&\Base::instance()->ref($key);
+		$var=&\F3\Base::instance()->ref($key);
 		foreach ($this->document as $key=>$field)
 			$var[$key]=$field;
 	}
@@ -352,7 +352,7 @@ class Mapper extends \DB\Cursor {
 	*	@param $db object
 	*	@param $collection string
 	**/
-	function __construct(\DB\Mongo $db,$collection) {
+	function __construct(\F3\DB\Mongo $db,$collection) {
 		$this->db=$db;
 		$this->collection=$db->selectcollection($collection);
 		$this->reset();

--- a/db/mongo/session.php
+++ b/db/mongo/session.php
@@ -20,7 +20,7 @@
 
 */
 
-namespace DB\Mongo;
+namespace F3\DB\Mongo;
 
 //! MongoDB-managed session handler
 class Session extends Mapper {
@@ -67,7 +67,7 @@ class Session extends Mapper {
 		if ($this->dry())
 			return FALSE;
 		if ($this->get('ip')!=$this->_ip || $this->get('agent')!=$this->_agent) {
-			$fw=\Base::instance();
+			$fw=\F3\Base::instance();
 			if (!isset($this->onsuspect) || FALSE===$fw->call($this->onsuspect,array($this,$id))) {
 				//NB: `session_destroy` can't be called at that stage (`session_start` not completed)
 				$this->destroy($id);
@@ -159,12 +159,12 @@ class Session extends Mapper {
 
 	/**
 	*	Instantiate class
-	*	@param $db \DB\Mongo
+	*	@param $db \F3\DB\Mongo
 	*	@param $table string
 	*	@param $onsuspect callback
 	*	@param $key string
 	**/
-	function __construct(\DB\Mongo $db,$table='sessions',$onsuspect=NULL,$key=NULL) {
+	function __construct(\F3\DB\Mongo $db,$table='sessions',$onsuspect=NULL,$key=NULL) {
 		parent::__construct($db,$table);
 		$this->onsuspect=$onsuspect;
 		session_set_save_handler(
@@ -176,7 +176,7 @@ class Session extends Mapper {
 			array($this,'cleanup')
 		);
 		register_shutdown_function('session_commit');
-		$fw=\Base::instance();
+		$fw=\F3\Base::instance();
 		$headers=$fw->get('HEADERS');
 		$this->_csrf=$fw->hash($fw->get('ROOT').$fw->get('BASE')).'.'.
 			$fw->hash(mt_rand());

--- a/db/sql.php
+++ b/db/sql.php
@@ -20,7 +20,7 @@
 
 */
 
-namespace DB;
+namespace F3\DB;
 
 //! PDO wrapper
 class SQL {
@@ -147,8 +147,8 @@ class SQL {
 			$cmds=array($cmds);
 			$args=array($args);
 		}
-		$fw=\Base::instance();
-		$cache=\Cache::instance();
+		$fw=\F3\Base::instance();
+		$cache=\F3\Cache::instance();
 		$result=FALSE;
 		for ($i=0;$i<$count;$i++) {
 			$cmd=$cmds[$i];
@@ -329,7 +329,7 @@ class SQL {
 				'FIELD','TYPE','DEFVAL','NULLABLE','Y','PKEY','P')
 		);
 		if (is_string($fields))
-			$fields=\Base::instance()->split($fields);
+			$fields=\F3\Base::instance()->split($fields);
 		foreach ($cmd as $key=>$val)
 			if (preg_match('/'.$key.'/',$this->engine)) {
 				// Improve InnoDB performance on MySQL with
@@ -371,7 +371,7 @@ class SQL {
 	function quote($val,$type=\PDO::PARAM_STR) {
 		return $this->engine=='odbc'?
 			(is_string($val)?
-				\Base::instance()->stringify(str_replace('\'','\'\'',$val)):
+				\F3\Base::instance()->stringify(str_replace('\'','\'\'',$val)):
 				$val):
 			$this->pdo->quote($val,$type);
 	}
@@ -454,7 +454,7 @@ class SQL {
 	*	@param $options array
 	**/
 	function __construct($dsn,$user=NULL,$pw=NULL,array $options=NULL) {
-		$fw=\Base::instance();
+		$fw=\F3\Base::instance();
 		$this->uuid=$fw->hash($this->dsn=$dsn);
 		if (preg_match('/^.+?(?:dbname|database)=(.+?)(?=;|$)/is',$dsn,$parts))
 			$this->dbname=$parts[1];

--- a/db/sql/mapper.php
+++ b/db/sql/mapper.php
@@ -20,10 +20,10 @@
 
 */
 
-namespace DB\SQL;
+namespace F3\DB\SQL;
 
 //! SQL data mapper
-class Mapper extends \DB\Cursor {
+class Mapper extends \F3\DB\Cursor {
 
 	protected
 		//! PDO wrapper
@@ -168,7 +168,7 @@ class Mapper extends \DB\Cursor {
 		}
 		$mapper->query=array(clone($mapper));
 		if (isset($mapper->trigger['load']))
-			\Base::instance()->call($mapper->trigger['load'],$mapper);
+			\F3\Base::instance()->call($mapper->trigger['load'],$mapper);
 		return $mapper;
 	}
 
@@ -363,7 +363,7 @@ class Mapper extends \DB\Cursor {
 			unset($field);
 		}
 		if (!$dry && isset($this->trigger['load']))
-			\Base::instance()->call($this->trigger['load'],$this);
+			\F3\Base::instance()->call($this->trigger['load'],$this);
 		return $out;
 	}
 
@@ -386,7 +386,7 @@ class Mapper extends \DB\Cursor {
 			if ($field['pkey'])
 				$pkeys[$key]=$field['previous'];
 		if (isset($this->trigger['beforeinsert']) &&
-			\Base::instance()->call($this->trigger['beforeinsert'],
+			\F3\Base::instance()->call($this->trigger['beforeinsert'],
 				array($this,$pkeys))===FALSE)
 			return $this;
 		foreach ($this->fields as $key=>&$field) {
@@ -430,7 +430,7 @@ class Mapper extends \DB\Cursor {
 					$this->fields[$inc]['pdo_type'],$this->_id)):
 				array($filter,$nkeys));
 			if (isset($this->trigger['afterinsert']))
-				\Base::instance()->call($this->trigger['afterinsert'],
+				\F3\Base::instance()->call($this->trigger['afterinsert'],
 					array($this,$pkeys));
 		}
 		return $this;
@@ -450,7 +450,7 @@ class Mapper extends \DB\Cursor {
 			if ($field['pkey'])
 				$pkeys[$key]=$field['previous'];
 		if (isset($this->trigger['beforeupdate']) &&
-			\Base::instance()->call($this->trigger['beforeupdate'],
+			\F3\Base::instance()->call($this->trigger['beforeupdate'],
 				array($this,$pkeys))===FALSE)
 			return $this;
 		foreach ($this->fields as $key=>$field)
@@ -470,7 +470,7 @@ class Mapper extends \DB\Cursor {
 			$sql='UPDATE '.$this->table.' SET '.$pairs.$filter;
 			$this->db->exec($sql,$args);
 			if (isset($this->trigger['afterupdate']))
-				\Base::instance()->call($this->trigger['afterupdate'],
+				\F3\Base::instance()->call($this->trigger['afterupdate'],
 					array($this,$pkeys));
 		}
 		return $this;
@@ -517,13 +517,13 @@ class Mapper extends \DB\Cursor {
 		}
 		parent::erase();
 		if (isset($this->trigger['beforeerase']) &&
-			\Base::instance()->call($this->trigger['beforeerase'],
+			\F3\Base::instance()->call($this->trigger['beforeerase'],
 				array($this,$pkeys))===FALSE)
 			return 0;
 		$out=$this->db->
 			exec('DELETE FROM '.$this->table.' WHERE '.$filter.';',$args);
 		if (isset($this->trigger['aftererase']))
-			\Base::instance()->call($this->trigger['aftererase'],
+			\F3\Base::instance()->call($this->trigger['aftererase'],
 				array($this,$pkeys));
 		return $out;
 	}
@@ -555,7 +555,7 @@ class Mapper extends \DB\Cursor {
 	**/
 	function copyfrom($var,$func=NULL) {
 		if (is_string($var))
-			$var=\Base::instance()->get($var);
+			$var=\F3\Base::instance()->get($var);
 		if ($func)
 			$var=call_user_func($func,$var);
 		foreach ($var as $key=>$val)
@@ -569,7 +569,7 @@ class Mapper extends \DB\Cursor {
 	*	@param $key string
 	**/
 	function copyto($key) {
-		$var=&\Base::instance()->ref($key);
+		$var=&\F3\Base::instance()->ref($key);
 		foreach ($this->fields+$this->adhoc as $key=>$field)
 			$var[$key]=$field['value'];
 	}
@@ -619,7 +619,7 @@ class Mapper extends \DB\Cursor {
 	*	@param $fields array|string
 	*	@param $ttl int
 	**/
-	function __construct(\DB\SQL $db,$table,$fields=NULL,$ttl=60) {
+	function __construct(\F3\DB\SQL $db,$table,$fields=NULL,$ttl=60) {
 		$this->db=$db;
 		$this->engine=$db->driver();
 		if ($this->engine=='oci')

--- a/db/sql/session.php
+++ b/db/sql/session.php
@@ -20,7 +20,7 @@
 
 */
 
-namespace DB\SQL;
+namespace F3\DB\SQL;
 
 //! SQL-managed session handler
 class Session extends Mapper {
@@ -67,7 +67,7 @@ class Session extends Mapper {
 		if ($this->dry())
 			return FALSE;
 		if ($this->get('ip')!=$this->_ip || $this->get('agent')!=$this->_agent) {
-			$fw=\Base::instance();
+			$fw=\F3\Base::instance();
 			if (!isset($this->onsuspect) || FALSE===$fw->call($this->onsuspect,array($this,$id))) {
 				//NB: `session_destroy` can't be called at that stage (`session_start` not completed)
 				$this->destroy($id);
@@ -159,13 +159,13 @@ class Session extends Mapper {
 
 	/**
 	*	Instantiate class
-	*	@param $db \DB\SQL
+	*	@param $db \F3\DB\SQL
 	*	@param $table string
 	*	@param $force bool
 	*	@param $onsuspect callback
 	*	@param $key string
 	**/
-	function __construct(\DB\SQL $db,$table='sessions',$force=TRUE,$onsuspect=NULL,$key=NULL) {
+	function __construct(\F3\DB\SQL $db,$table='sessions',$force=TRUE,$onsuspect=NULL,$key=NULL) {
 		if ($force) {
 			$eol="\n";
 			$tab="\t";
@@ -198,7 +198,7 @@ class Session extends Mapper {
 			array($this,'cleanup')
 		);
 		register_shutdown_function('session_commit');
-		$fw=\Base::instance();
+		$fw=\F3\Base::instance();
 		$headers=$fw->get('HEADERS');
 		$this->_csrf=$fw->hash($fw->get('ROOT').$fw->get('BASE')).'.'.
 			$fw->hash(mt_rand());

--- a/f3.php
+++ b/f3.php
@@ -20,6 +20,8 @@
 
 */
 
+namespace F3;
+
 //! Legacy mode enabler
 class F3 {
 

--- a/image.php
+++ b/image.php
@@ -20,6 +20,8 @@
 
 */
 
+namespace F3;
+
 //! Image manipulation tools
 class Image {
 

--- a/log.php
+++ b/log.php
@@ -20,6 +20,8 @@
 
 */
 
+namespace F3;
+
 //! Custom logger
 class Log {
 

--- a/magic.php
+++ b/magic.php
@@ -20,8 +20,10 @@
 
 */
 
+namespace F3;
+
 //! PHP magic wrapper
-abstract class Magic implements ArrayAccess {
+abstract class Magic implements \ArrayAccess {
 
 	/**
 	*	Return TRUE if key is not empty

--- a/markdown.php
+++ b/markdown.php
@@ -20,6 +20,8 @@
 
 */
 
+namespace F3;
+
 //! Markdown-to-HTML converter
 class Markdown extends Prefab {
 

--- a/matrix.php
+++ b/matrix.php
@@ -20,6 +20,8 @@
 
 */
 
+namespace F3;
+
 //! Generic array utilities
 class Matrix extends Prefab {
 

--- a/session.php
+++ b/session.php
@@ -20,6 +20,8 @@
 
 */
 
+namespace F3;
+
 //! Cache-based session handler
 class Session {
 
@@ -176,7 +178,7 @@ class Session {
 			array($this,'cleanup')
 		);
 		register_shutdown_function('session_commit');
-		$fw=\Base::instance();
+		$fw=Base::instance();
 		$headers=$fw->get('HEADERS');
 		$this->_csrf=$fw->hash($fw->get('ROOT').$fw->get('BASE')).'.'.
 			$fw->hash(mt_rand());

--- a/smtp.php
+++ b/smtp.php
@@ -20,6 +20,8 @@
 
 */
 
+namespace F3;
+
 //! SMTP plug-in
 class SMTP extends Magic {
 

--- a/template.php
+++ b/template.php
@@ -20,6 +20,8 @@
 
 */
 
+namespace F3;
+
 //! XML-style template engine
 class Template extends Preview {
 
@@ -66,7 +68,7 @@ class Template extends Preview {
 								(preg_match('/^\'.*\'$/',$pair[2]) ||
 									preg_match('/\$/',$pair[2])?
 									$pair[2]:
-									\Base::instance()->stringify($pair[2]));
+									Base::instance()->stringify($pair[2]));
 						},$pairs)).')+get_defined_vars()':
 					'get_defined_vars()';
 		$ttl=isset($attrib['ttl'])?(int)$attrib['ttl']:0;
@@ -339,7 +341,7 @@ class Template extends Preview {
 	*	return object
 	**/
 	function __construct() {
-		$ref=new ReflectionClass(__CLASS__);
+		$ref=new \ReflectionClass(__CLASS__);
 		$this->tags='';
 		foreach ($ref->getmethods() as $method)
 			if (preg_match('/^_(?=[[:alpha:]])/',$method->name))

--- a/test.php
+++ b/test.php
@@ -20,6 +20,8 @@
 
 */
 
+namespace F3;
+
 //! Unit test kit
 class Test {
 

--- a/utf.php
+++ b/utf.php
@@ -20,6 +20,8 @@
 
 */
 
+namespace F3;
+
 //! Unicode string manager
 class UTF extends Prefab {
 

--- a/web.php
+++ b/web.php
@@ -20,6 +20,8 @@
 
 */
 
+namespace F3;
+
 //! Wrapper for various HTTP utilities
 class Web extends Prefab {
 

--- a/web/geo.php
+++ b/web/geo.php
@@ -20,10 +20,10 @@
 
 */
 
-namespace Web;
+namespace F3\Web;
 
 //! Geo plug-in
-class Geo extends \Prefab {
+class Geo extends \F3\Prefab {
 
 	/**
 	*	Return information about specified Unix time zone
@@ -52,8 +52,8 @@ class Geo extends \Prefab {
 	*	@param $ip string
 	**/
 	function location($ip=NULL) {
-		$fw=\Base::instance();
-		$web=\Web::instance();
+		$fw=\F3\Base::instance();
+		$web=\F3\Web::instance();
 		if (!$ip)
 			$ip=$fw->get('IP');
 		$public=filter_var($ip,FILTER_VALIDATE_IP,
@@ -89,8 +89,8 @@ class Geo extends \Prefab {
 	*	@param $longitude float
 	**/
 	function weather($latitude,$longitude) {
-		$fw=\Base::instance();
-		$web=\Web::instance();
+		$fw=\F3\Base::instance();
+		$web=\F3\Web::instance();
 		$query=array(
 			'lat'=>$latitude,
 			'lon'=>$longitude

--- a/web/google/staticmap.php
+++ b/web/google/staticmap.php
@@ -20,7 +20,7 @@
 
 */
 
-namespace Web\Google;
+namespace F3\Web\Google;
 
 //! Google Static Maps API v2 plug-in
 class StaticMap {
@@ -49,8 +49,8 @@ class StaticMap {
 	*	@return string
 	**/
 	function dump() {
-		$fw=\Base::instance();
-		$web=\Web::instance();
+		$fw=\F3\Base::instance();
+		$web=\F3\Web::instance();
 		$out='';
 		return ($req=$web->request(
 			self::URL_Static.'?'.array_reduce(

--- a/web/openid.php
+++ b/web/openid.php
@@ -20,10 +20,10 @@
 
 */
 
-namespace Web;
+namespace F3\Web;
 
 //! OpenID consumer
-class OpenID extends \Magic {
+class OpenID extends \F3\Magic {
 
 	protected
 		//! OpenID provider endpoint URL
@@ -49,7 +49,7 @@ class OpenID extends \Magic {
 			strtolower($url['host']).(isset($url['path'])?$url['path']:'/').
 			(isset($url['query'])?('?'.$url['query']):'');
 		// HTML-based discovery of OpenID provider
-		$req=\Web::instance()->
+		$req=\F3\Web::instance()->
 			request($this->args['identity'],array('proxy'=>$proxy));
 		if (!$req)
 			return FALSE;
@@ -141,7 +141,7 @@ class OpenID extends \Magic {
 	*	@param $reqd string|array
 	**/
 	function auth($proxy=NULL,$attr=array(),array $reqd=NULL) {
-		$fw=\Base::instance();
+		$fw=\F3\Base::instance();
 		$root=$fw->get('SCHEME').'://'.$fw->get('HOST');
 		if (empty($this->args['trust_root']))
 			$this->args['trust_root']=$root.$fw->get('BASE').'/';
@@ -182,7 +182,7 @@ class OpenID extends \Magic {
 			$var=array();
 			foreach ($this->args as $key=>$val)
 				$var['openid.'.$key]=$val;
-			$req=\Web::instance()->request(
+			$req=\F3\Web::instance()->request(
 				$this->url,
 				array(
 					'method'=>'POST',

--- a/web/pingback.php
+++ b/web/pingback.php
@@ -20,10 +20,10 @@
 
 */
 
-namespace Web;
+namespace F3\Web;
 
 //! Pingback 1.0 protocol (client and server) implementation
-class Pingback extends \Prefab {
+class Pingback extends \F3\Prefab {
 
 	protected
 		//! Transaction history
@@ -35,7 +35,7 @@ class Pingback extends \Prefab {
 	*	@param $url
 	**/
 	protected function enabled($url) {
-		$web=\Web::instance();
+		$web=\F3\Web::instance();
 		$req=$web->request($url);
 		$found=FALSE;
 		if ($req && $req['body']) {
@@ -62,8 +62,8 @@ class Pingback extends \Prefab {
 	*	@param $source string
 	**/
 	function inspect($source) {
-		$fw=\Base::instance();
-		$web=\Web::instance();
+		$fw=\F3\Base::instance();
+		$web=\F3\Web::instance();
 		$parts=parse_url($source);
 		if (empty($parts['scheme']) || empty($parts['host']) ||
 			$parts['host']==$fw->get('HOST')) {
@@ -108,7 +108,7 @@ class Pingback extends \Prefab {
 	*	@param $path string
 	**/
 	function listen($func,$path=NULL) {
-		$fw=\Base::instance();
+		$fw=\F3\Base::instance();
 		if (PHP_SAPI!='cli') {
 			header('X-Powered-By: '.$fw->get('PACKAGE'));
 			header('Content-Type: application/xml; '.
@@ -116,7 +116,7 @@ class Pingback extends \Prefab {
 		}
 		if (!$path)
 			$path=$fw->get('BASE');
-		$web=\Web::instance();
+		$web=\F3\Web::instance();
 		$args=xmlrpc_decode_request($fw->get('BODY'),$method,$charset);
 		$options=array('encoding'=>$charset);
 		if ($method=='pingback.ping' && isset($args[0],$args[1])) {


### PR DESCRIPTION
Update fatfree core to use the top level vendor namespace `F3`. Refs #110. Required following refactoring most of which was automatable:

  * Add `namespace F3` to all top level files programatically, and amend the namespace of files that already had a namespace to include prefix `F3`.
  * Replace all relative refs to non F3 classes in the to level with absolute refs.
  * Amend all absolute refs to F3 class in non top level classes.
  * Minor touch up to autoloader - use require_once() not require().
  * Fix some implicit refs to non prefixed namespaces in Preview::token().
  * The sample app and test at /bcosca/fatfree will have to be updated. Already done sucessfully. Will push shortly.