### PR TITLE
ensure special Content-Type and Content_Length headers are properly handled

### DIFF
--- a/base.php
+++ b/base.php
@@ -2049,6 +2049,10 @@ final class Base extends Prefab implements ArrayAccess {
 				if (substr($key,0,5)=='HTTP_')
 					$headers[strtr(ucwords(strtolower(strtr(
 						substr($key,5),'_',' '))),' ','-')]=&$_SERVER[$key];
+				elseif ($key == "CONTENT_TYPE")
+					$headers['Content-Type']=&$_SERVER[$key];
+				elseif ($key == "CONTENT_LENGTH")
+					$headers['Content-Length']=&$_SERVER[$key];
 		if (isset($headers['X-HTTP-Method-Override']))
 			$_SERVER['REQUEST_METHOD']=$headers['X-HTTP-Method-Override'];
 		elseif ($_SERVER['REQUEST_METHOD']=='POST' && isset($_POST['_method']))


### PR DESCRIPTION
The way Fat Free populates the `HEADERS` in `hive` is great,
however, `Content-Length` and `Content-Type` headers are not prefixed with `HTTP_` in the `$_SERVER` array. Nevertheless they are headers.

These need to be handled specially.

I'm trying to build a REST api using Fat Free, and POST/PUT requests can send different kinds of data, so I have to check the content type and see whether it's `application/x-www-form-urlencoded` or `application/json` or `multipart/form-data` and handle the payload accordingly.
Right now I'm having to patch the `HEADERS` in the application during bootstrap.