### PR TITLE
Suggestion: onget/onset hooks

### DIFF
--- a/db/cursor.php
+++ b/db/cursor.php
@@ -374,6 +374,24 @@ abstract class Cursor extends \Magic implements \IteratorAggregate {
 	}
 
 	/**
+	 *	Define onget trigger
+	 *	@return callback
+	 *	@param $func callback
+	 **/
+	function onget($func) {
+		return $this->trigger['onget']=$func;
+	}
+
+	/**
+	 *	Define onset trigger
+	 *	@return callback
+	 *	@param $func callback
+	 **/
+	function onset($func) {
+		return $this->trigger['onset']=$func;
+	}
+
+	/**
 	*	Reset cursor
 	*	@return NULL
 	**/

--- a/db/sql/mapper.php
+++ b/db/sql/mapper.php
@@ -93,6 +93,8 @@ class Mapper extends \DB\Cursor {
 			if ($this->fields[$key]['value']!==$val ||
 				$this->fields[$key]['default']!==$val && is_null($val))
 				$this->fields[$key]['changed']=TRUE;
+			if (isset($this->trigger['onset']))
+				\Base::instance()->call($this->trigger['onset'],array($key,&$val,$this));
 			return $this->fields[$key]['value']=$val;
 		}
 		// adjust result on existing expressions
@@ -112,11 +114,15 @@ class Mapper extends \DB\Cursor {
 	function &get($key) {
 		if ($key=='_id')
 			return $this->_id;
-		elseif (array_key_exists($key,$this->fields))
-			return $this->fields[$key]['value'];
+		if (array_key_exists($key,$this->fields))
+			$val=$this->fields[$key]['value'];
 		elseif (array_key_exists($key,$this->adhoc))
-			return $this->adhoc[$key]['value'];
-		user_error(sprintf(self::E_Field,$key),E_USER_ERROR);
+			$val=$this->adhoc[$key]['value'];
+		else
+			user_error(sprintf(self::E_Field,$key),E_USER_ERROR);
+		if (isset($this->trigger['onget']))
+			\Base::instance()->call($this->trigger['onget'],array($key,&$val,$this));
+		return $val;
 	}
 
 	/**


### PR DESCRIPTION
Hi,

this [topic](https://groups.google.com/forum/#!topic/f3-framework/7cOpHTKm-W4) made me wondering if the framework couldn't provide an easy way to manipulate the data coming from or going to the database. Easier than overloading the `get()` and `set()` methods.

Hence this proposal to add `onget` and `onset` hooks:
```php
// auto-hash passwords
$mapper->onset(function($key,&$val){
  if ($key=='password')
    $val=Bcrypt::instance()->hash($val);
});

// auto-serialize/unserialize array data
$mapper->onset(function($key,&$val){
  if ($key=='data')
    $val=serialize($val);
});
$mapper->onget(function($key,&$val){
  if ($key=='data')
    $val=unserialize($val);
});
```

Actually @ikkez has implemented something similar in Cortex.

What do you guys think?