### PR TITLE
Proposal for route wildcards to match empty strings

### DIFF
--- a/base.php
+++ b/base.php
@@ -1384,7 +1384,7 @@ final class Base extends Prefab implements ArrayAccess {
 		$case=$this->hive['CASELESS']?'i':'';
 		preg_match('/^'.
 			preg_replace('/((\\\{)?@(\w+\b)(?(2)\\\}))/','(?P<\3>[^\/\?]+)',
-			str_replace('\*','([^\?]+)',preg_quote($pattern,'/'))).
+			str_replace('\*','([^\?]*)',preg_quote($pattern,'/'))).
 				'\/?(?:\?.*)?$/'.$case.'um',$url,$args);
 		return $args;
 	}
@@ -1402,8 +1402,12 @@ final class Base extends Prefab implements ArrayAccess {
 			user_error(self::E_Routes,E_USER_ERROR);
 		// Match specific routes first
 		$paths=[];
-		foreach ($keys=array_keys($this->hive['ROUTES']) as $key)
-			$paths[]=str_replace('@','*@',$key);
+		foreach ($keys=array_keys($this->hive['ROUTES']) as $key) {
+			$path=str_replace('@','*@',$key);
+			if (substr($path,-1)!='*')
+				$path.='+';
+			$paths[]=$path;
+		}
 		$vals=array_values($this->hive['ROUTES']);
 		array_multisort($paths,SORT_DESC,$keys,$vals);
 		$this->hive['ROUTES']=array_combine($keys,$vals);


### PR DESCRIPTION
I recently discovered that wildcards used in routes don't match empty strings. So:

* `/foo*` matches `/foo/` but not `/foo`
* `/*` matches `/foo` but not `/`

This looks a bit counter-intuitive as it goes against the usual meaning of the `*` wildcard used in regexes or shells.

Hence this proposal to have wildcards match empty strings as well. This way, a route like `GET /*` could really catch *everything*.

NB: the tweak in `array_multisort` is here for `/foo` to have higher precedence order than `/foo*`.