### PR TITLE
Fixed `SQL->log()` documentation

### DIFF
--- a/db/sql.php
+++ b/db/sql.php
@@ -263,7 +263,7 @@ class SQL {
 	}
 
 	/**
-	*	Return SQL profiler results (or disable logging)
+	*	Return SQL profiler results (or clear the log)
 	*	@param $flag bool
 	*	@return string
 	**/


### PR DESCRIPTION
The method `log()` clears the log instead of disabling it.

**Example**

```php
$db = new DB\SQL('sqlite::memory:');

$db->exec('SELECT 1');
var_dump($db->log());

$db->exec('SELECT 2');
var_dump($db->log(false));

$db->exec('SELECT 3');
var_dump($db->log());
```

**Result**

```
string(17) "(0.1ms) SELECT 1
"
NULL
string(17) "(0.0ms) SELECT 3
"
```