### PR TITLE
Sessions custom cache

### DIFF
--- a/session.php
+++ b/session.php
@@ -34,8 +34,8 @@ class Session {
 		$_ip,
 		//! Suspect callback
 		$onsuspect,
-        //! Cache instance
-        $_cache;
+		//! Cache instance
+		$_cache;
 
 	/**
 	*	Open session


### PR DESCRIPTION
Following the issue #140 I created earlier, here's an implementation of how this could be achieved while keeping full compatibility with the existing code.

Example of code:
```
$cache = Cache::instance();    // Regular cache (depends on CACHE config variable)
$sessionCacheInstance = new \Cache('folder=var/sessions/');    // Custom cache for sessions only
$session = new \Session(null, null, $sessionCacheInstance);

\Base::instance()->set('SESSION.myvar', $myValue);   // Data will be stored in var/sessions/ no matter what CACHE config variable says
```

Any feedback welcome