### PR TITLE
PSR-3 compliant Log class

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
 	"license": "GPL-3.0",
 	"require": {
 		"php": ">=5.3.6",
-        "psr/log": "1.0.0"
+		"psr/log": "1.0.0"
 	},
 	"autoload": {
 		"classmap": ["."]

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,8 @@
 	"homepage": "http://fatfreeframework.com/",
 	"license": "GPL-3.0",
 	"require": {
-		"php": ">=5.3.6"
+		"php": ">=5.3.6",
+        "psr/log": "1.0.0"
 	},
 	"autoload": {
 		"classmap": ["."]


### PR DESCRIPTION
I've adapted the Log class to comply with PSR-3 specifications. I think it could be interesting to get closer to standards on such aspect.

Pros:
- Keeps 100% compatibility with existing code
- Standardized logging, increased compatibility with other libraries
- Adds the notion of log level (but without any filtering possible at that time)

Cons:
- Adds [psr/log](https://packagist.org/packages/psr/log) as a Composer dependency

Below is a test case for the new implementation:

``` php
require 'vendor/autoload.php';
require 'log.php';

$logger = new Log('test.log');

$logger->debug('debug');
$logger->warning('warning {foo}', ['foo' => 'bar']);
$logger->emergency(
    'emergency {exception}',
    ['exception' => new Exception("it's a test"), 'unused_context_key' => 'nothing']
);

$logger->log('invalid_level', 'my message');
```

Result in `test.log`:

```
Wed, 06 Jul 2016 13:23:16 +0200 DEBUG debug
Wed, 06 Jul 2016 13:23:16 +0200 WARNING warning bar
Wed, 06 Jul 2016 13:23:16 +0200 EMERGENCY emergency Exception: it's a test in /var/www/fatfree-core/test.php:27
Stack trace:
#0 {main}
```
