### PR TITLE
Fixed the too short columns `session_id` and and `ip` of DB\SQL\Session

### DIFF
--- a/db/sql/session.php
+++ b/db/sql/session.php
@@ -179,9 +179,9 @@ class Session extends Mapper {
 						((($name=$db->name())&&$db->driver()!='pgsql')?
 							($name.'.'):''))).
 				$table.' ('.$eol.
-					$tab.$db->quotekey('session_id').' VARCHAR(40),'.$eol.
+					$tab.$db->quotekey('session_id').' VARCHAR(255),'.$eol.
 					$tab.$db->quotekey('data').' TEXT,'.$eol.
-					$tab.$db->quotekey('ip').' VARCHAR(40),'.$eol.
+					$tab.$db->quotekey('ip').' VARCHAR(45),'.$eol.
 					$tab.$db->quotekey('agent').' VARCHAR(300),'.$eol.
 					$tab.$db->quotekey('stamp').' INTEGER,'.$eol.
 					$tab.'PRIMARY KEY ('.$db->quotekey('session_id').')'.$eol.


### PR DESCRIPTION
# IPv6

It looks like our magic number should be `45` instead of `40` because of IPv4 tunneling.

Source: [Maximum length of the textual representation of an IPv6 address?](http://stackoverflow.com/a/166157/870798)

# Session

Session ID's have an arbitrary length. PHP `7.1.0` for instance supports a custom length with [`session.sid_length`](http://php.net/manual/en/session.configuration.php#ini.session.sid-length) and older PHP versions support different algorithms with different ID lengths by defining [`session.hash_function`](http://php.net/manual/en/session.configuration.php#ini.session.hash-function).

# Proposal

We should use the magic constants `45` for IP addresses and `255` (as of PHP `7.1`) for session IDs.