### PR TITLE
Issue 143 bis

### DIFF
--- a/db/sql/mapper.php
+++ b/db/sql/mapper.php
@@ -90,9 +90,11 @@ class Mapper extends \DB\Cursor {
 		if (array_key_exists($key,$this->fields)) {
 			$val=is_null($val) && $this->fields[$key]['nullable']?
 				NULL:$this->db->value($this->fields[$key]['pdo_type'],$val);
-			if ($this->fields[$key]['value']!==$val ||
-				$this->fields[$key]['default']!==$val && is_null($val))
+			if ($this->fields[$key]['old_value']!==$val ||
+				$this->fields[$key]['default']!==$val && is_null($val)) {
 				$this->fields[$key]['changed']=TRUE;
+				$this->fields[$key]['old_value']=$val;
+            }
 			return $this->fields[$key]['value']=$val;
 		}
 		// adjust result on existing expressions
@@ -163,6 +165,7 @@ class Mapper extends \DB\Cursor {
 			else
 				continue;
 			$mapper->{$var}[$key]['value']=$val;
+			$mapper->{$var}[$key]['old_value']=$val;
 			if ($var=='fields' && $mapper->{$var}[$key]['pkey'])
 				$mapper->{$var}[$key]['previous']=$val;
 		}
@@ -535,6 +538,7 @@ class Mapper extends \DB\Cursor {
 	function reset() {
 		foreach ($this->fields as &$field) {
 			$field['value']=NULL;
+			$field['old_value']=NULL;
 			$field['changed']=FALSE;
 			if ($field['pkey'])
 				$field['previous']=NULL;

--- a/db/sql/mapper.php
+++ b/db/sql/mapper.php
@@ -370,6 +370,18 @@ class Mapper extends \DB\Cursor {
 	}
 
 	/**
+	*	Save mapped record
+	*	@return NULL
+	**/
+    function save() {
+        foreach($this->fields as $key => $value)
+            if (!$this->fields[$key]["changed"] &&
+                $this->fields[$key]["old_value"]!==$this->fields[$key]["value"])
+                $this->fields[$key]["changed"]=TRUE;
+        parent::save();
+    }
+
+	/**
 	*	Insert new record
 	*	@return object
 	**/


### PR DESCRIPTION
This second PR is based on PR 150 : https://github.com/bcosca/fatfree-core/pull/150

It fixes the '++' operator using the old_value and creating a specific "save" method in the sql.php (so has to be added in the other specialized cursors). It verifies if value has been changed before saving.
This is because the '++' operator do not trigger any of the magic methods. 