### PR TITLE
NEW: custom FORMATS

### DIFF
--- a/base.php
+++ b/base.php
@@ -842,7 +842,9 @@ final class Base extends Prefab implements ArrayAccess {
 				extract($conv);
 				if (!array_key_exists($pos,$args))
 					return $expr[0];
-				if (isset($type))
+				if (isset($type)) {
+					if (isset($this->hive['FORMATS'][$type]))
+						return $this->call($this->hive['FORMATS'][$type],[$args[$pos],$mod,$prop]);
 					switch ($type) {
 						case 'plural':
 							preg_match_all('/(?<tag>\w+)'.
@@ -928,6 +930,7 @@ final class Base extends Prefab implements ArrayAccess {
 						default:
 							return $expr[0];
 					}
+				}
 				return $args[$pos];
 			},
 			$val
@@ -2172,6 +2175,7 @@ final class Base extends Prefab implements ArrayAccess {
 			'EXCEPTION'=>NULL,
 			'EXEMPT'=>NULL,
 			'FALLBACK'=>$this->fallback,
+			'FORMATS'=>[],
 			'FRAGMENT'=>isset($uri['fragment'])?$uri['fragment']:'',
 			'HALT'=>TRUE,
 			'HIGHLIGHT'=>FALSE,


### PR DESCRIPTION
This is a proposal to allow users to define custom formats.

In particular, it would help fixing bcosca/fatfree#970 by providing a means to define plural schemes for languages other than English:

``` php
// custom format definition
$f3->set('FORMATS.polish',function($nb,$mod){
  preg_match_all('/(\d)\s*\{\s*(.+?)\s*\}/',$mod,$matches,PREG_SET_ORDER);
  $terms=[];
  foreach ($matches as $m)
    $terms[$m[1]]=$m[2];
  $k=$nb==1?1:(preg_match('/(?<!1)[234]$/',$nb)?2:5);
  return isset($terms[$k]) ? str_replace('#',$nb,$terms[$k]) : $nb;
});

// usage
$line='{0, polish, 1 {# linia}, 2 {# linie}, 5 {# linii}}';
echo $f3->format($line,1); // 1 linia
echo $f3->format($line,2); // 2 linie
echo $f3->format($line,5); // 2 linii
echo $f3->format($line,12); // 12 linii
echo $f3->format($line,21); // 21 linii
echo $f3->format($line,22); // 22 linie
```
