### PR TITLE
extend method

### DIFF
--- a/base.php
+++ b/base.php
@@ -597,6 +597,20 @@ final class Base extends Prefab implements ArrayAccess {
 	}
 
 	/**
+	 *	Extend hive array variable with default values from $src
+	 *	@return array
+	 *	@param $key string
+	 *	@param $src string|array
+	 **/
+	function extend($key,$src) {
+		$ref=&$this->ref($key);
+		if (!$ref)
+			$ref=[];
+		$ref+=is_string($src)?$this->hive[$src]:$src;
+		return $ref;
+	}
+
+	/**
 	*	Convert backslashes to slashes
 	*	@return string
 	*	@param $str string

--- a/base.php
+++ b/base.php
@@ -597,17 +597,20 @@ final class Base extends Prefab implements ArrayAccess {
 	}
 
 	/**
-	 *	Extend hive array variable with default values from $src
-	 *	@return array
-	 *	@param $key string
-	 *	@param $src string|array
-	 **/
-	function extend($key,$src) {
+	*	Extend hive array variable with default values from $src
+	*	@return array
+	*	@param $key string
+	*	@param $src string|array
+	*	@param $keep bool
+	**/
+	function extend($key,$src,$keep=FALSE) {
 		$ref=&$this->ref($key);
 		if (!$ref)
 			$ref=[];
-		$ref+=is_string($src)?$this->hive[$src]:$src;
-		return $ref;
+		$out=$ref+(is_string($src)?$this->hive[$src]:$src);
+		if ($keep)
+			$ref=$out;
+		return $out;
 	}
 
 	/**


### PR DESCRIPTION
Here is a little proposal for a new extend method.
It's similar to the `merge` method, but only copies not existing keys. This way you can easily merge default values into existing hive array variables.

```php
// actual var
$f3->set('vars',['foo'=>'xyz', 2, 1]);
// apply defaults
$f3->extend('vars',[1,2,'cherry','bar'=>'baz','foo'=>'abc']);

Array (
    [foo] => xyz
    [0] => 2
    [1] => 1
    [2] => cherry
    [bar] => baz
)
```

using `merge` would lead to:

```php
$f3->set('vars',['foo'=>'xyz', 2, 1]);
$f3->merge('vars',[1,2,'cherry','bar'=>'baz','foo'=>'abc'], TRUE);

Array (
    [foo] => abc
    [0] => 2
    [1] => 1
    [2] => 1
    [3] => 2
    [4] => cherry
    [bar] => baz
)
```

