### PR TITLE
drop mset for locales to optimize lang key loading #92

### DIFF
--- a/base.php
+++ b/base.php
@@ -366,7 +366,11 @@ final class Base extends Prefab implements ArrayAccess {
 			$lex=$this->lexicon($this->hive['LOCALES'],$ttl);
 		case 'LOCALES':
 			if (isset($lex) || $lex=$this->lexicon($val,$ttl))
-				$this->mset($lex,$this->hive['PREFIX'],$ttl);
+				foreach ($lex as $lkey=>$lval) {
+					$lref=&$this->ref($this->hive['PREFIX'].$lkey);
+					$lref=$lval;
+					unset($lref);
+				}
 			break;
 		case 'TZ':
 			date_default_timezone_set($val);


### PR DESCRIPTION
Here is a working approach that speeds up adding locales **x4**

Testes with 3 languages and ~150 language keys. Before:
```time: 39,77ms,  memory: 1048,6```

after this change:
```time: 10,3ms,  memory: 1048,6```

This is faster because we simply skip all things that `set` does. We can do this, because dictionary files are actually no config files and we don't expect special config variables in there (which `set` is checking for every time) and since the lexicon file is cached via `$ttl` in the whole, we don't need the caching checks in `set` at all. That'll give a boost.
