### PR TITLE
markdown: require start of line/whitespace for text processing (fixed #136)

### DIFF
--- a/markdown.php
+++ b/markdown.php
@@ -321,7 +321,7 @@ class Markdown extends Prefab {
 		$tmp='';
 		while ($str!=$tmp)
 			$str=preg_replace_callback(
-				'/(?<!\\\\)([*_]{1,3})(.*?)(?!\\\\)\1(?=[\s[:punct:]]|$)/',
+				'/(?<=\s|^)(?<!\\\\)([*_]{1,3})(.*?)(?!\\\\)\1(?=[\s[:punct:]]|$)/',
 				function($expr) {
 					switch (strlen($expr[1])) {
 						case 1:


### PR DESCRIPTION
This PR is going to fix https://github.com/bcosca/fatfree-core/issues/136

The modified regex will check for a whitespace or a new line in front of the character (_, *,  ~ etc.)  / string that should be converted to bold or italic.

F3's checks still pass. See it in action here: http://www.phpliveregex.com/p/huo