### PR TITLE
Adding CORS Force Ability

### DIFF
--- a/base.php
+++ b/base.php
@@ -1451,7 +1451,7 @@ final class Base extends Prefab implements ArrayAccess {
 		$this->hive['ROUTES']=array_combine($keys,$vals);
 		// Convert to BASE-relative URL
 		$req=$this->rel(urldecode($this->hive['PATH']));
-		if ($cors=(isset($this->hive['HEADERS']['Origin']) &&
+		if ($cors=((isset($this->hive['HEADERS']['Origin']) || $this->hive['CORS']['force']) &&
 			$this->hive['CORS']['origin'])) {
 			$cors=$this->hive['CORS'];
 			header('Access-Control-Allow-Origin: '.$cors['origin']);
@@ -2195,7 +2195,8 @@ final class Base extends Prefab implements ArrayAccess {
 				'origin'=>FALSE,
 				'credentials'=>FALSE,
 				'expose'=>FALSE,
-				'ttl'=>0
+				'ttl'=>0,
+				'force'=>false
 			],
 			'DEBUG'=>0,
 			'DIACRITICS'=>[],


### PR DESCRIPTION
Force enabling CORS for development purposes.
The current behaviour of the CORS support are checking the `HEADERS.Origin`, if it exist, then the CORS support are enabled. 

By adding the `force` var, it will always activate the CORS support, no matter if the  `HEADERS.Origin` are exist or not.

Using:

``` php
// This will enable the CORS Support forcefully.
\F3::set('CORS.force', true);
```
