### PR TITLE
NEW: Sql ttl arrays

### DIFF
--- a/db/sql.php
+++ b/db/sql.php
@@ -46,9 +46,7 @@ class SQL {
 		//! Number of rows affected by query
 		$rows=0,
 		//! SQL log
-		$log,
-		//! last used hash keys
-		$hash=[];
+		$log;
 
 	/**
 	*	Begin SQL transaction
@@ -255,21 +253,7 @@ class SQL {
 		}
 		if ($this->trans && $auto)
 			$this->commit();
-		if (isset($hash))
-			$this->hash[]=$hash;
 		return $result;
-	}
-
-	/**
-	*	Return last used cache hash keys
-	*	@param bool $clear
-	*	@return array
-	*/
-	function hash($clear=FALSE) {
-		$cache_keys=$this->hash;
-		if ($clear)
-			$this->hash=[];
-		return $cache_keys;
 	}
 
 	/**

--- a/db/sql.php
+++ b/db/sql.php
@@ -132,11 +132,14 @@ class SQL {
 	*	@return array|int|FALSE
 	*	@param $cmds string|array
 	*	@param $args string|array
-	*	@param $ttl int
+	*	@param $ttl int|array
 	*	@param $log bool
 	*	@param $stamp bool
 	**/
 	function exec($cmds,$args=NULL,$ttl=0,$log=TRUE,$stamp=FALSE) {
+		$tag='';
+		if (is_array($ttl))
+			list($ttl,$tag)=$ttl;
 		$auto=FALSE;
 		if (is_null($args))
 			$args=[];
@@ -175,7 +178,7 @@ class SQL {
 			$keys=$vals=[];
 			if ($fw->get('CACHE') && $ttl && ($cached=$cache->exists(
 				$hash=$fw->hash($this->dsn.$cmd.
-				$fw->stringify($arg)).'.sql',$result)) &&
+				$fw->stringify($arg)).($tag?'.'.$tag:'').'.sql',$result)) &&
 				$cached[0]+$ttl>microtime(TRUE)) {
 				foreach ($arg as $key=>$val) {
 					$vals[]=$fw->stringify(is_array($val)?$val[0]:$val);
@@ -280,7 +283,7 @@ class SQL {
 	*	@return array|FALSE
 	*	@param $table string
 	*	@param $fields array|string
-	*	@param $ttl int
+	*	@param $ttl int|array
 	**/
 	function schema($table,$fields=NULL,$ttl=0) {
 		if (strpos($table,'.'))

--- a/db/sql/mapper.php
+++ b/db/sql/mapper.php
@@ -195,7 +195,7 @@ class Mapper extends \DB\Cursor {
 	*	@param $fields string
 	*	@param $filter string|array
 	*	@param $options array
-	*	@param $ttl int
+	*	@param $ttl int|array
 	**/
 	function select($fields,$filter=NULL,array $options=NULL,$ttl=0) {
 		if (!$options)
@@ -297,7 +297,7 @@ class Mapper extends \DB\Cursor {
 	*	@return static[]
 	*	@param $filter string|array
 	*	@param $options array
-	*	@param $ttl int
+	*	@param $ttl int|array
 	**/
 	function find($filter=NULL,array $options=NULL,$ttl=0) {
 		if (!$options)
@@ -322,7 +322,7 @@ class Mapper extends \DB\Cursor {
 	*	Count records that match criteria
 	*	@return int
 	*	@param $filter string|array
-	*	@param $ttl int
+	*	@param $ttl int|array
 	**/
 	function count($filter=NULL,$ttl=0) {
 		$sql='SELECT COUNT(*) AS '.
@@ -624,7 +624,7 @@ class Mapper extends \DB\Cursor {
 	*	@param $db object
 	*	@param $table string
 	*	@param $fields array|string
-	*	@param $ttl int
+	*	@param $ttl int|array
 	**/
 	function __construct(\DB\SQL $db,$table,$fields=NULL,$ttl=60) {
 		$this->db=$db;


### PR DESCRIPTION
This PR is a follow up of [this thread](https://groups.google.com/forum/#!topic/f3-framework/t0hYxPVuFeE).

It reverts https://github.com/bcosca/fatfree-core/commit/3122b5881ee792f4ab3ad71522444f1900e7820c and gives instead the possibility to tag cached queries, so that it becomes possible to selectively reset a subset of all the cached queries.

The change is achieved through ttl arrays in order to keep BC:

``` php
// controller1
$db->exec($sql,$args,[$ttl,'product']); // <-- tag that query as 'product' related
$mapper->find($filter1,$opts,[$ttl,'product']); // idem

// controller2
$mapper->find($filter2,$opts,[$ttl,'product']); // idem

// controller3
$mapper->find($filter3,$opts,[$ttl,'customer']); // different tagging here

// controller 4 (clear 'product' related cached queries)
$cache->reset('.product.sql');
```
