### PR TITLE
Correct handling of TTL for Redis

### DIFF
--- a/base.php
+++ b/base.php
@@ -2417,7 +2417,11 @@ class Cache extends Prefab {
 			case 'apcu':
 				return apc_store($ndx,$data,$ttl);
 			case 'redis':
-				return $this->ref->set($ndx,$data,['ex'=>$ttl]);
+				if($ttl > 0) {
+					return $this->ref->set($ndx,$data,array('ex'=>$ttl));
+				} else {
+					return $this->ref->set($ndx,$data);
+				}
 			case 'memcache':
 				return memcache_set($this->ref,$ndx,$data,0,$ttl);
 			case 'wincache':

--- a/base.php
+++ b/base.php
@@ -2417,11 +2417,7 @@ class Cache extends Prefab {
 			case 'apcu':
 				return apc_store($ndx,$data,$ttl);
 			case 'redis':
-				if($ttl > 0) {
-					return $this->ref->set($ndx,$data,array('ex'=>$ttl));
-				} else {
-					return $this->ref->set($ndx,$data);
-				}
+				return $this->ref->set($ndx,$data, $ttl ? ['ex'=>$ttl] : []);
 			case 'memcache':
 				return memcache_set($this->ref,$ndx,$data,0,$ttl);
 			case 'wincache':


### PR DESCRIPTION
If TTL is 0 the 'ex' flag is not setting the key as it would instantly expire. To create a key without TTL we need to omit the 'ex' flag.