### PR TITLE
fread replaced with readfile() for simple Web->send() usecase

### DIFF
--- a/web.php
+++ b/web.php
@@ -140,6 +140,12 @@ class Web extends Prefab {
 			header('Content-Length: '.$size);
 			header('X-Powered-By: '.Base::instance()->get('PACKAGE'));
 		}
+		if(!$kbps && $flush) {
+			while (ob_get_level())
+				ob_end_clean();
+			readfile($file);
+			return $size;
+		}
 		$ctr=0;
 		$handle=fopen($file,'rb');
 		$start=microtime(TRUE);


### PR DESCRIPTION
When you don't want to rate-limit a file download to the web browser (which is likely the most common use case for Web->send()), then readfile() is the fastest and cleanest way to do it. Benchmarks showing this can be found [here](http://www.garfieldtech.com/blog/readfile-memory). To quote that source:

> As it turns out, readfile(), fpassthru(), and stream_copy_to_stream() are nearly identical internally. All use the PHP streams API internally, and in fact the same internal operation, php_stream_passthru(). Depending on your OS, it will either use mmap or do its own chunked iteration using 8 KB chunks. That is, in the worst case, **it will do exactly the same thing you would have done manually, but all done in C code so that it's faster**. If your OS supports it, it will use mmap(), which is an OS level operation that allows contents on disk to be read as if they were in RAM; the OS takes care of paging the file in and out of physical memory as needed.


Currently, for the most common use case, there are 20 lines of PHP code that serve only to create processing overhead where just 1 line of code does a better job.

[note - this is an updated version of PR  #104 that takes advantage of the new $flush parameter to avoid breaking CLI use cases and test cases that rely on output buffering]