### PR TITLE
Fix locales precedence order and charset hyphen

### DIFF
--- a/base.php
+++ b/base.php
@@ -1009,10 +1009,11 @@ final class Base extends Prefab implements ArrayAccess {
 					$country=@constant('ISO::CC_'.strtolower($parts[1])))
 					$locale.='-'.$country;
 			}
-			$locales[]=$locale;
+			$locale=str_replace('-','_',$locale);
 			$locales[]=$locale.'.'.ini_get('default_charset');
+			$locales[]=$locale;
 		}
-		setlocale(LC_ALL,str_replace('-','_',$locales));
+		setlocale(LC_ALL,$locales);
 		return implode(',',$this->languages);
 	}
 


### PR DESCRIPTION
I submit these 2 fixes as a PR, because I'm surprised that it didn't come earlier (so I may be missing something).

Fix 1:
Locales precedence order: I believe that `fr_FR.UTF-8` should be processed before `fr_FR`.

Fix 2:
The replacement of hyphens by underscores should not affect the charset:
```
fr-FR.UTF-8 => fr_FR.UTF-8
```