### PR TITLE
Return only the client's IP when using the X-Forwarded-For header

### DIFF
--- a/base.php
+++ b/base.php
@@ -1163,7 +1163,7 @@ final class Base extends Prefab implements ArrayAccess {
 		return isset($headers['Client-IP'])?
 			$headers['Client-IP']:
 			(isset($headers['X-Forwarded-For'])?
-				$headers['X-Forwarded-For']:
+				explode(',',$headers['X-Forwarded-For'])[0]:
 				(isset($_SERVER['REMOTE_ADDR'])?
 					$_SERVER['REMOTE_ADDR']:''));
 	}


### PR DESCRIPTION
This PR fixes https://github.com/bcosca/fatfree/issues/985 by extracting the client's IP (first comma separated segment) from the `X-Forwarded-For` header.