### PR TITLE
Fix session handler read() method for PHP7 (need strict string)

### DIFF
--- a/session.php
+++ b/session.php
@@ -64,7 +64,7 @@ class Session {
 	function read($id) {
 		$this->sid=$id;
 		if (!$data=$this->_cache->get($id.'.@'))
-			return FALSE;
+			return '';
 		if ($data['ip']!=$this->_ip || $data['agent']!=$this->_agent) {
 			$fw=Base::instance();
 			if (!isset($this->onsuspect) ||


### PR DESCRIPTION
[As mentioned in the documentation](http://php.net/manual/en/class.sessionhandlerinterface.php), session handlers must return a string to the `read()` method.
This precise point is now enforced by PHP7 typechecking, leading to the following error when using `session_regenerate_id()`: 

```
session_regenerate_id(): Failed to create(read) session ID: user (path: )
```
Returning an empty string instead of FALSE works as expected.


Thread on PHP7 mailing-list + similar issue on another framework:
- https://bugs.php.net/bug.php?id=70871
- https://github.com/Inchoo/Inchoo_PHP7/issues/4