### PR TITLE
NEW: quick erase flag on Mongo/SQL mappers

### DIFF
--- a/db/mongo/mapper.php
+++ b/db/mongo/mapper.php
@@ -292,10 +292,17 @@ class Mapper extends \DB\Cursor {
 	/**
 	*	Delete current record
 	*	@return bool
+	*	@param $quick bool
 	*	@param $filter array
 	**/
-	function erase($filter=NULL) {
+	function erase($filter=NULL,$quick=TRUE) {
 		if ($filter) {
+			if (!$quick) {
+				foreach ($this->find($filter) as $mapper)
+					if (!$mapper->erase())
+						return FALSE;
+				return TRUE;
+			}
 			return $this->legacy?
 				$this->collection->remove($filter):
 				$this->collection->deletemany($filter);

--- a/db/sql/mapper.php
+++ b/db/sql/mapper.php
@@ -484,10 +484,17 @@ class Mapper extends \DB\Cursor {
 	/**
 	*	Delete current record
 	*	@return int
+	*	@param $quick bool
 	*	@param $filter string|array
 	**/
-	function erase($filter=NULL) {
+	function erase($filter=NULL,$quick=TRUE) {
 		if (isset($filter)) {
+			if (!$quick) {
+				$out=0;
+				foreach ($this->find($filter) as $mapper)
+					$out+=$mapper->erase();
+				return $out;
+			}
 			$args=[];
 			if (is_array($filter)) {
 				$args=isset($filter[1]) && is_array($filter[1])?


### PR DESCRIPTION
Here's a proposal to add a parameter to the mappers `erase()` method, so that we can choose one of the two following behaviors:

**Quick erase:** (default)
Delete all records at once and skip before/aftererase hooks.

```php
$mapper->erase($filter);
```


**Slow erase:**
Delete and trigger before/aftererase hooks for each record one by one.

```php
$mapper->erase($filter,FALSE);
```

NB: Jig mapper does only offer the 2nd behaviour. We should maybe implement the first one (quick erase), for consistency purposes.