### PR TITLE
NEW: Recaptcha plugin

### DIFF
--- a/web/google/recaptcha.php
+++ b/web/google/recaptcha.php
@@ -1,0 +1,57 @@
+<?php
+
+/*
+
+	Copyright (c) 2009-2017 F3::Factory/Bong Cosca, All rights reserved.
+
+	This file is part of the Fat-Free Framework (http://fatfreeframework.com).
+
+	This is free software: you can redistribute it and/or modify it under the
+	terms of the GNU General Public License as published by the Free Software
+	Foundation, either version 3 of the License, or later.
+
+	Fat-Free Framework is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+	General Public License for more details.
+
+	You should have received a copy of the GNU General Public License along
+	with Fat-Free Framework.  If not, see <http://www.gnu.org/licenses/>.
+
+*/
+
+namespace Web\Google;
+
+//! Google ReCAPTCHA v2 plug-in
+class Recaptcha {
+
+	const
+		//! API URL
+		URL_Recaptcha='https://www.google.com/recaptcha/api/siteverify';
+
+	/**
+	 *	Verify reCAPTCHA response
+	 *	@param string $secret
+	 *	@param string $response
+	 *	@return bool
+	 **/
+	static function verify($secret,$response=NULL) {
+		$fw=\Base::instance();
+		if (!isset($response))
+			$response=$fw->get('POST.g-recaptcha-response');
+		if (!$response)
+			return FALSE;
+		$web=\Web::instance();
+		$out=$web->request(self::URL_Recaptcha,[
+			'method'=>'POST',
+			'content'=>http_build_query([
+				'secret'=>$secret,
+				'response'=>$response,
+				'remoteip'=>$fw->get('IP'),
+			]),
+		]);
+		return isset($out['body']) && ($json=json_decode($out['body'],TRUE)) &&
+				isset($json['success']) && $json['success'];
+	}
+
+}


### PR DESCRIPTION
Usage:

1) Request API keys for your domain [here](https://www.google.com/recaptcha/admin?hl=en). You should get two keys: a site key and a secret key. NB: you can request keys for `localhost` or IP addresses as well.
2) Add the reCAPTCHA widget to your page:
    * `<div class="g-recaptcha" data-sitekey="YOUR_SITEKEY"></div>`
    * `<script src='https://www.google.com/recaptcha/api.js'></script>`
3) Validate the response on the server side with the `Recaptcha` plugin:
```php
if (!Web\Google\Recaptcha::verify('YOUR_SECRETKEY')) {
  // reCAPTCHA validation failed
}
```

I still prefer the native captcha feature coming with the framework, as it doesn't require any external javascript nor request, but since I needed reCAPTCHA on a project, I thought I'd share it.

NB: the plugin is a fat-free refactoring of Google's [own plugin](https://github.com/google/recaptcha).