### PR TITLE
debounce Cursor->paginate subset

### DIFF
--- a/db/cursor.php
+++ b/db/cursor.php
@@ -152,7 +152,7 @@ abstract class Cursor extends \Magic implements \IteratorAggregate {
 		if ($bounce)
 			$pos=max(0,min($pos,$count-1));
 		return [
-			'subset'=>(!$bounce && $pos<$count)?$this->find($filter,
+			'subset'=>($bounce || $pos<$count)?$this->find($filter,
 				array_merge(
 					$options?:[],
 					['limit'=>$size,'offset'=>$pos*$size]

--- a/db/cursor.php
+++ b/db/cursor.php
@@ -143,24 +143,26 @@ abstract class Cursor extends \Magic implements \IteratorAggregate {
 	*	@param $filter string|array
 	*	@param $options array
 	*	@param $ttl int
+	*	@param $bounce bool
 	**/
 	function paginate(
-		$pos=0,$size=10,$filter=NULL,array $options=NULL,$ttl=0) {
+		$pos=0,$size=10,$filter=NULL,array $options=NULL,$ttl=0,$bounce=TRUE) {
 		$total=$this->count($filter,$options,$ttl);
 		$count=ceil($total/$size);
-		$pos=max(0,min($pos,$count-1));
+		if ($bounce)
+			$pos=max(0,min($pos,$count-1));
 		return [
-			'subset'=>$this->find($filter,
+			'subset'=>(!$bounce && $pos<$count)?$this->find($filter,
 				array_merge(
 					$options?:[],
 					['limit'=>$size,'offset'=>$pos*$size]
 				),
 				$ttl
-			),
+			):[],
 			'total'=>$total,
 			'limit'=>$size,
 			'count'=>$count,
-			'pos'=>$pos<$count?$pos:0
+			'pos'=>$bounce?($pos<$count?$pos:0):$pos
 		];
 	}
 


### PR DESCRIPTION
This pull-request adds an option to "debounce" the pagination cursor, in case it exceeds the result boundaries. I had an issue with the default behaviour on implementing a REST service, because I don't know how many total items the whole collection has before running the query, and returning always the same last items when the position exceeds the max subset count isn't an option for me, as this can lead to issues on the frontend implementation. I have a case where I need to merge multiple paginated subsets and if one reached its end, it should be empty instead of giving the last possible subset.