### PR TITLE
Fix "Undefined index: CLI" error

### DIFF
--- a/base.php
+++ b/base.php
@@ -2685,7 +2685,7 @@ class View extends Prefab {
 			$hive=$fw->hive();
 		}
 		if ($this->level<1 || $implicit) {
-			if (!$hive['CLI'] && !headers_sent() &&
+			if ((!isset($hive['CLI']) || !$hive['CLI']) && !headers_sent() &&
 				!preg_grep ('/^Content-Type:/',headers_list()))
 				header('Content-Type: '.($mime?:'text/html').'; '.
 					'charset='.$fw->get('ENCODING'));

--- a/base.php
+++ b/base.php
@@ -2685,7 +2685,7 @@ class View extends Prefab {
 			$hive=$fw->hive();
 		}
 		if ($this->level<1 || $implicit) {
-			if ((!isset($hive['CLI']) || !$hive['CLI']) && !headers_sent() &&
+			if (!$fw->get('CLI') && !headers_sent() &&
 				!preg_grep ('/^Content-Type:/',headers_list()))
 				header('Content-Type: '.($mime?:'text/html').'; '.
 					'charset='.$fw->get('ENCODING'));


### PR DESCRIPTION
Commit 894c3ea9beab2ea77e08e2f116d94ca58a6f73d2 seems to have introduced a bug that makes the framework crash when attempting to render a template because `$hive['CLI']` does not exist.
I'm proposing this patch to fix this issue.