### PR TITLE
JIG with JSON: Native `JSON_PRETTY_PRINT` constant

### DIFF
--- a/db/jig.php
+++ b/db/jig.php
@@ -80,7 +80,7 @@ class Jig {
 		$fw=\Base::instance();
 		switch ($this->format) {
 			case self::FORMAT_JSON:
-				$out=json_encode($data,@constant('JSON_PRETTY_PRINT'));
+				$out=json_encode($data,JSON_PRETTY_PRINT);
 				break;
 			case self::FORMAT_Serialized:
 				$out=$fw->serialize($data);


### PR DESCRIPTION
* F3 3.6.0 requires PHP >= 5.4
* The `JSON_PRETTY_PRINT` constant is available since PHP 5.4.0