### PR TITLE
pass carriage return of multiline dictionary keys

### DIFF
--- a/base.php
+++ b/base.php
@@ -1038,7 +1038,7 @@ final class Base extends Prefab implements ArrayAccess {
 							elseif (!array_key_exists(
 								$key=$prefix.$match['lval'],$lex))
 								$lex[$key]=trim(preg_replace(
-									'/\\\\\h*\r?\n/','',$match['rval']));
+									'/\\\\\h*\r?\n/',"\n",$match['rval']));
 					}
 				}
 		if ($ttl)


### PR DESCRIPTION
I think it would actually be much more useful to keep the newline in multiline dictionary keys, so one would be able to reuse that in further parts of the application, i.e. with `nl2br` or intepret such on the client side.

```ini
headline = Hello World \
           Welcome to my site
```

```html
{{ nl2br(@headline) }}
```
