### PR TITLE
Return a status code > 0 when dying on error

### DIFF
--- a/base.php
+++ b/base.php
@@ -1255,7 +1255,7 @@ final class Base extends Prefab implements ArrayAccess {
 				'</body>'.$eol.
 				'</html>');
 		if ($this->hive['HALT'])
-			die;
+			die(1);
 	}
 
 	/**


### PR DESCRIPTION
The final call to `die()` in the `\Base::error()` method should specify a status code > 0 to indicate a failure. Otherwise a shellscript (for example) would not detect the error and resume its process even though the PHP script has failed.