### PR TITLE
Add Dependency Injection support with CONTAINER variable

### DIFF
--- a/base.php
+++ b/base.php
@@ -1735,6 +1735,8 @@ final class Base extends Prefab implements ArrayAccess {
 			if ($parts[2]=='->') {
 				if (is_subclass_of($parts[1],'Prefab'))
 					$parts[1]=call_user_func($parts[1].'::instance');
+				elseif ($container=$this->get('CONTAINER'))
+					$parts[1]=call_user_func($container.'::instance')->get($parts[1]);
 				else {
 					$ref=new ReflectionClass($parts[1]);
 					$parts[1]=method_exists($parts[1],'__construct') && $args?

--- a/base.php
+++ b/base.php
@@ -1735,8 +1735,18 @@ final class Base extends Prefab implements ArrayAccess {
 			if ($parts[2]=='->') {
 				if (is_subclass_of($parts[1],'Prefab'))
 					$parts[1]=call_user_func($parts[1].'::instance');
-				elseif ($container=$this->get('CONTAINER'))
-					$parts[1]=call_user_func($container.'::instance')->get($parts[1]);
+				elseif ($container=$this->get('CONTAINER')) {
+					if (is_object($container) && is_callable([$container,'has']) && $container->has($parts[1]))	//PSR11
+						$parts[1]=call_user_func([$container,'get'])->get($parts[1]);
+					elseif (is_callable($container))
+						$parts[1]=call_user_func($container,$parts[1]);
+					elseif (is_string($container) && is_subclass_of($container,'Prefab'))
+						$parts[1]=call_user_func($container.'::instance')->get($parts[1]);
+					else
+						user_error(sprintf(self::E_Class,
+							$this->stringify($container)),
+							E_USER_ERROR);
+				}
 				else {
 					$ref=new ReflectionClass($parts[1]);
 					$parts[1]=method_exists($parts[1],'__construct') && $args?

--- a/base.php
+++ b/base.php
@@ -1737,7 +1737,7 @@ final class Base extends Prefab implements ArrayAccess {
 					$parts[1]=call_user_func($parts[1].'::instance');
 				elseif ($container=$this->get('CONTAINER')) {
 					if (is_object($container) && is_callable([$container,'has']) && $container->has($parts[1]))	//PSR11
-						$parts[1]=call_user_func([$container,'get'])->get($parts[1]);
+						$parts[1]=call_user_func([$container,'get'],$parts[1]);
 					elseif (is_callable($container))
 						$parts[1]=call_user_func($container,$parts[1]);
 					elseif (is_string($container) && is_subclass_of($container,'Prefab'))


### PR DESCRIPTION
F3 works almost out-of-the-box with DI frameworks like [PHP-DI](https://github.com/PHP-DI/PHP-DI).
The only thing it lacks is the DI "bootstrap" code that starts all the injection.

I found that the best way to achieve that is to add an alternative to the `\Base::call()` method. Currently it works like this (let's say to call `\MyController->index`):
1. If the `\MyController` is a subclass of `\Prefab`, we call `\MyController::instance()->index`
2. Otherwise, we instanciate `\MyController` and call the method directly on it

With the DI support I'm proposing, it's almost the same, but the 2nd alternative becomes the 3rd:
1. If `\MyController` is a subclass of `\Prefab`, we call `\MyController::instance()->index`
2. If there is a framework variable called `CONTAINER` defined, we use it as a `\Prefab` to retrieve an instance of the `\MyController` via its `get()` method
3. Otherwise, we instanciate `\MyController` and call the method directly on it

Pretty simple, isn't it?
With this I had no other F3-related thing to do to integrate PHP-DI on my application, and everything works the same.

If you're asking "Why `CONTAINER`?", it's just the generic term for the dependency injection main component.