### PR TITLE
fix sorting issues with sub-queries on SQL Server, bcosca/fatfree#1052

### DIFF
--- a/db/sql/mapper.php
+++ b/db/sql/mapper.php
@@ -348,7 +348,7 @@ class Mapper extends \DB\Cursor {
 		foreach ($this->adhoc as $key=>$field)
 			$adhoc.=','.$field['expr'].' AS '.$this->db->quotekey($key);
 		$fields='*'.$adhoc;
-		if (preg_match('/mssql|dblib|sqlsrv/',$this->engine) && (strncmp($this->db->version(),'11',2)<0))
+		if (preg_match('/mssql|dblib|sqlsrv/',$this->engine))
 			$fields='TOP 100 PERCENT '.$fields;
 		list($sql,$args)=$this->stringify($fields,$filter,$options);
 		$sql='SELECT COUNT(*) AS '.$this->db->quotekey('_rows').' '.

--- a/db/sql/mapper.php
+++ b/db/sql/mapper.php
@@ -236,7 +236,7 @@ class Mapper extends \DB\Cursor {
 				explode(',',$options['group'])));
 		}
 		if ($options['order']) {
-			$sql.=' ORDER BY '.implode(',',array_map(
+			$order=' ORDER BY '.implode(',',array_map(
 				function($str) use($db) {
 					return preg_match('/^\h*(\w+[._\-\w]*)(?:\h+((?:ASC|DESC)[\w\h]*))?\h*$/i',
 						$str,$parts)?
@@ -245,33 +245,36 @@ class Mapper extends \DB\Cursor {
 				},
 				explode(',',$options['order'])));
 		}
+		// SQL Server fixes
 		if (preg_match('/mssql|sqlsrv|odbc/', $this->engine) &&
 			($options['limit'] || $options['offset'])) {
-			$pkeys=[];
-			foreach ($this->fields as $key=>$field)
-				if ($field['pkey'])
-					$pkeys[]=$key;
+			// order by pkey when no ordering option was given
+			if (!$options['order'])
+				foreach ($this->fields as $key=>$field)
+					if ($field['pkey']) {
+						$order=' ORDER BY '.$db->quotekey($key);
+						break;
+					}
 			$ofs=$options['offset']?(int)$options['offset']:0;
 			$lmt=$options['limit']?(int)$options['limit']:0;
 			if (strncmp($db->version(),'11',2)>=0) {
-				// SQL Server 2012
-				if (!$options['order'])
-					$sql.=' ORDER BY '.$db->quotekey($pkeys[0]);
-				$sql.=' OFFSET '.$ofs.' ROWS';
+				// SQL Server >= 2012
+				$sql.=$order.' OFFSET '.$ofs.' ROWS';
 				if ($lmt)
 					$sql.=' FETCH NEXT '.$lmt.' ROWS ONLY';
 			}
 			else {
 				// SQL Server 2008
-				$sql=str_replace('SELECT',
+				$sql=preg_replace('/SELECT/',
 					'SELECT '.
 					($lmt>0?'TOP '.($ofs+$lmt):'').' ROW_NUMBER() '.
-					'OVER (ORDER BY '.
-						$db->quotekey($pkeys[0]).') AS rnum,',$sql);
+					'OVER ('.$order.') AS rnum,',$sql.$order,1);
 				$sql='SELECT * FROM ('.$sql.') x WHERE rnum > '.($ofs);
 			}
 		}
 		else {
+			if (isset($order))
+				$sql.=$order;
 			if ($options['limit'])
 				$sql.=' LIMIT '.(int)$options['limit'];
 			if ($options['offset'])
@@ -344,7 +347,10 @@ class Mapper extends \DB\Cursor {
 		$adhoc='';
 		foreach ($this->adhoc as $key=>$field)
 			$adhoc.=','.$field['expr'].' AS '.$this->db->quotekey($key);
-		list($sql,$args)=$this->stringify('*'.$adhoc,$filter,$options);
+		$fields='*'.$adhoc;
+		if (preg_match('/mssql|dblib|sqlsrv/',$this->engine) && (strncmp($this->db->version(),'11',2)<0))
+			$fields='TOP 100 PERCENT '.$fields;
+		list($sql,$args)=$this->stringify($fields,$filter,$options);
 		$sql='SELECT COUNT(*) AS '.$this->db->quotekey('_rows').' '.
 			'FROM ('.$sql.') AS '.$this->db->quotekey('_temp');
 		$result=$this->db->exec($sql,$args,$ttl);


### PR DESCRIPTION
Some fixes to resolve https://github.com/bcosca/fatfree/pull/1052
@dexwerx I've checked your proposal and applied them with only slightly adjustments.
Tested on SQL Server2008 and 2012 here, as well as on the other engines just to be sure it breaks nothing else and it's looking good. I wasn't able to get sorting on an adhoc field + limit + offset working for sqlsrv 2008 though, but I start to believe that it's either not working in general for that specific version or it's my old version here.. got no problems on sqlsrv 2012 though.
Please check if that resolves your issue. 