### PR TITLE
Improve auth.php intval() call replaced with int type cast

### DIFF
--- a/auth.php
+++ b/auth.php
@@ -115,7 +115,7 @@ class Auth {
 	*	@param $pw string
 	**/
 	protected function _ldap($id,$pw) {
-		$port=intval($this->args['port']?:389);
+		$port=(int)($this->args['port']?:389);
 		$filter=$this->args['filter']=$this->args['filter']?:"uid=".$id;
 		$this->args['attr']=$this->args['attr']?:["uid"];
 		array_walk($this->args['attr'],


### PR DESCRIPTION
There is one usage of `intval()` that we could convert to an `(int)` type cast. `intval()` has a function call overhead, and in older PHP versions, `(int)` cast is [2-3 times faster](https://3v4l.org/YrQhf) than `intval()`. 

Sending a PR hoping you could review and merge. 

Thank you.