### PR TITLE
check if _agent is too long for SQL based sessions

### DIFF
--- a/db/sql/session.php
+++ b/db/sql/session.php
@@ -208,6 +208,9 @@ class Session extends Mapper {
 		if ($key)
 			$fw->$key=$this->_csrf;
 		$this->_agent=isset($headers['User-Agent'])?$headers['User-Agent']:'';
+		if (strlen($this->_agent) > 300) {
+			$this->_agent = substr($this->_agent, 0, 300);
+		}
 		$this->_ip=$fw->IP;
 	}
 


### PR DESCRIPTION
This makes sure you can still create sessions when your agent is too long. Although 300 is long enough, it's best to make it fail proof.