### PR TITLE
add JAR.lifetime option, #178

### DIFF
--- a/base.php
+++ b/base.php
@@ -395,10 +395,11 @@ final class Base extends Prefab implements ArrayAccess {
 		$ref=$val;
 		if (preg_match('/^JAR\b/',$key)) {
 			if ($key=='JAR.lifetime')
-				$this->set('JAR.expire',is_int($val)?$time+$val:strtotime($val));
+				$this->set('JAR.expire',$val==0?0:
+					(is_int($val)?$time+$val:strtotime($val)));
 			else {
 				if ($key=='JAR.expire')
-					$this->hive['JAR']['lifetime']=($val-$time);
+					$this->hive['JAR']['lifetime']=max(0,$val-$time);
 				$jar=$this->unserialize($this->serialize($this->hive['JAR']));
 				unset($jar['expire']);
 				if (!headers_sent() && session_status()!=PHP_SESSION_ACTIVE)


### PR DESCRIPTION
Here is a proposal for #178 to add a `lifetime` param for the session and cookie settings `JAR`.
We got `JAR.expire` so far, which is a timestamp that is used for 
`session_set_cookie_params` (needs ttl) and `setcookie` (needs timestamp)

As this statement was hard to express in a config file
 `$f3->set('JAR.expire', time()+604800);`
you can now use the `lifetime` parameter to set a lifetime in seconds instead of a timestamp:

```ini
[globals]
JAR.lifetime  = 3600
```

It's also possible to use a string time (strtotime is baked in), i.e.:

```ini
JAR.lifetime = 2 hours
JAR.lifetime = 3 days
JAR.lifetime = 1 month
```

This `JAR.lifetime` parameter is synced with `JAR.expire`, when you update the one parameter, the other is recalculated accordingly:

```php
// JAR.lifetime = 2 hours
Array
(
    [expire] => 1514920993
    [lifetime] => 7200
)

// JAR.lifetime = 3 days
Array
(
    [expire] => 1515172993
    [lifetime] => 259200
)

// JAR.lifetime = 1 month
Array
(
    [expire] => 1517592193
    [lifetime] => 2678400
)
```

