### PR TITLE
Ensure valid route alias names

### DIFF
--- a/base.php
+++ b/base.php
@@ -1363,7 +1363,7 @@ final class Base extends Prefab implements ArrayAccess {
 				$this->route($item,$handler,$ttl,$kbps);
 			return;
 		}
-		preg_match('/([\|\w]+)\h+(?:(?:@?(.+?)\h*:\h*)?(@(\w+)|[^\h]+))'.
+		preg_match('/([\|\w]+)\h+(?:(?:@(\w+)\h*:\h*)?(@(\w+)|[^\h]+))'.
 			'(?:\h+\[('.implode('|',$types).')\])?/u',$pattern,$parts);
 		if (isset($parts[2]) && $parts[2])
 			$this->hive['ALIASES'][$alias=$parts[2]]=$parts[3];


### PR DESCRIPTION
I think that the regex in `$f3->route()` is a bit too permissive for aliases. It allows nearly all characters, in particular dots, while it should stick to the `\w` range.

What drew my attention is an issue for my f3-access plugin where the user has defined aliases with dots: https://github.com/xfra35/f3-access/issues/4

Additionally, there's that `?` after `@` which seems superfluous to me. But I could be missing something.