### PR TITLE
Fix URL parse with PHP < 5.4.7

### DIFF
--- a/base.php
+++ b/base.php
@@ -2282,7 +2282,7 @@ final class Base extends Prefab implements ArrayAccess {
 			$base=rtrim($this->fixslashes(
 				dirname($_SERVER['SCRIPT_NAME'])),'/');
 		$uri=parse_url((preg_match('/^\w+:\/\//',$_SERVER['REQUEST_URI'])?'':
-			'//'.$_SERVER['SERVER_NAME']).$_SERVER['REQUEST_URI']);
+			$_SERVER['REQUEST_SCHEME'].'://'.$_SERVER['SERVER_NAME']).$_SERVER['REQUEST_URI']);
 		$_SERVER['REQUEST_URI']=$uri['path'].
 			(isset($uri['query'])?'?'.$uri['query']:'').
 			(isset($uri['fragment'])?'#'.$uri['fragment']:'');


### PR DESCRIPTION
Bug : routes are "404 not found //example.com/"

We must provide the protocole in the URL scheme to be compatible with versions of PHP < 5.4.7 and > 5.4

See : http://php.net/manual/en/function.parse-url.php
PHP 5.4.7 - Fixed host recognition when scheme is omitted and a leading component separator is present