### PR TITLE
Method uppercase to avoid route failure

### DIFF
--- a/base.php
+++ b/base.php
@@ -2277,7 +2277,7 @@ final class Base extends Prefab implements ArrayAccess {
 		if (isset($headers['X-HTTP-Method-Override']))
 			$_SERVER['REQUEST_METHOD']=$headers['X-HTTP-Method-Override'];
 		elseif ($_SERVER['REQUEST_METHOD']=='POST' && isset($_POST['_method']))
-			$_SERVER['REQUEST_METHOD']=$_POST['_method'];
+			$_SERVER['REQUEST_METHOD']=strtoupper($_POST['_method']);
 		$scheme=isset($_SERVER['HTTPS']) && $_SERVER['HTTPS']=='on' ||
 			isset($headers['X-Forwarded-Proto']) &&
 			$headers['X-Forwarded-Proto']=='https'?'https':'http';


### PR DESCRIPTION
My use case is with simpleid/simpleid project. When trying to log in with OpenID 2 on http://osm.org the 3rd party send a long POST with a `_method=post` in it. I totally don't know if it comes from OpenID standard or not. Nonetheless, this make the authentication failed, because of this parsing.

Is there any rationale behind considering this parameter as the real method?