### PR TITLE
Fixed error description when (PSR-11) `CONTAINER` fails to resolve a class

### DIFF
--- a/base.php
+++ b/base.php
@@ -1777,7 +1777,7 @@ final class Base extends Prefab implements ArrayAccess {
 						$parts[1]=call_user_func($container.'::instance')->get($parts[1]);
 					else
 						user_error(sprintf(self::E_Class,
-							$this->stringify($container)),
+							$this->stringify($parts[1])),
 							E_USER_ERROR);
 				}
 				else {


### PR DESCRIPTION
This PR fixes the class resolving error description, e.g.

```
Invalid class 'ExampleController'
```

instead of

```
Invalid class League\Container\Container::__set_state([])
```

when working with a PSR-11 dependency injection container.