### PR TITLE
PCRE2 migration in PHP 7.3

### DIFF
--- a/template.php
+++ b/template.php
@@ -273,7 +273,7 @@ class Template extends Preview {
 		// Build tree structure
 		for ($ptr=0,$w=5,$len=strlen($text),$tree=[],$tmp='';$ptr<$len;)
 			if (preg_match('/^(.{0,'.$w.'}?)<(\/?)(?:F3:)?'.
-				'('.$this->tags.')\b((?:\s+[\w-.:@!]+'.
+				'('.$this->tags.')\b((?:\s+[\w.:@!-]+'.
 				'(?:\h*=\h*(?:"(?:.*?)"|\'(?:.*?)\'))?|'.
 				'\h*\{\{.+?\}\})*)\h*(\/?)>/is',
 				substr($text,$ptr),$match)) {


### PR DESCRIPTION
PHP 7.3 is just around the corner, and one of its changes include [PCRE2 migration](https://wiki.php.net/rfc/pcre2-migration). 

F3's template.php file has one regex pattern that would throw an error `preg_match(): Compilation failed: invalid range in character class at offset 113` in `\Template::parse()` method. 

I maintain a [list of PH 7.3 changes](https://ayesh.me/Upgrade-PHP-7.3#pcre2) and how to update them, which includes more details. 

For this particular issue, this PR fixes the regex by simply moving the offending hyphen to the end of the character class, so it's not considered a range. 

Thank you.