### PR TITLE
Fix OPTIONS method for REST requests, now returning only callable methods on handler

### DIFF
--- a/base.php
+++ b/base.php
@@ -1464,10 +1464,11 @@ final class Base extends Prefab implements ArrayAccess {
 			return;
 		}
 		foreach (explode('|',self::VERBS) as $method)
-			$this->route($method.' '.$url,is_string($class)?
-				$class.'->'.$this->hive['PREMAP'].strtolower($method):
-				[$class,$this->hive['PREMAP'].strtolower($method)],
-				$ttl,$kbps);
+			if (is_callable([$class,$this->hive['PREMAP'].strtolower($method)]))
+				$this->route($method.' '.$url,is_string($class)?
+					$class.'->'.$this->hive['PREMAP'].strtolower($method):
+					[$class,$this->hive['PREMAP'].strtolower($method)],
+					$ttl,$kbps);
 	}
 
 	/**


### PR DESCRIPTION
I'm proposing this PR to fix what seems to be a bug in the REST method mapping process.

With the given example in the [documentation](https://fatfreeframework.com/3.6/routing-engine#ReST:RepresentationalStateTransfer):
```php
class Item {
    function get() {}
    function post() {}
    function put() {}
    function delete() {}
}

$f3=require('lib/base.php');
$f3->map('/cart/@item','Item');
$f3->run();
```

we have the following behavior:

- calling GET on `/cart` will result in HTTP status 200 with empty body :heavy_check_mark: 
- calling PATCH on `/cart` will result in HTTP status 405 with empty body and the `Allow` header set to `POST,PUT,DELETE,OPTIONS` :heavy_check_mark: 
- calling OPTIONS `/cart` will result in HTTP status 200 with empty body and the `Allow` header set to `GET,HEAD,POST,PUT,PATCH,DELETE,CONNECT,OPTIONS` while obviously not all these methods are supported by the handler here :x:

That's because the `\Base::map()` method creates routes for all `\Base::VERBS` when called, while it should only do for methods that are _callable_ on the handler.

With my PR, calling OPTIONS `/cart` will result in HTTP status 200 with empty body and the `Allow` header set to `POST,PUT,DELETE,OPTIONS` as it should.

Be aware that I prefered using `is_callable()` instead of `method_exists()` because one may want to define a `__call()` method on the handler. In that case, the PR is useless as all methods will be detected as callable because of the catch-all `__call` method.