### PR TITLE
Fix HEADERS hive key not being populated when using \Base::mock()

### DIFF
--- a/base.php
+++ b/base.php
@@ -1351,11 +1351,11 @@ final class Base extends Prefab implements ArrayAccess {
 		$GLOBALS['_POST']=$verb=='POST'?$args:[];
 		$GLOBALS['_REQUEST']=array_merge($GLOBALS['_GET'],$GLOBALS['_POST']);
 		foreach ($headers?:[] as $key=>$val){
-            $this->hive['HEADERS'][$key]=$val;
-		    if (in_array(strtolower($key),['content-length','content-type']))
-                $_SERVER[strtr(strtoupper($key),'-','_')]=$val;
-		    else
-                $_SERVER['HTTP_'.strtr(strtoupper($key),'-','_')]=$val;
+			$this->hive['HEADERS'][$key]=$val;
+			if (in_array(strtolower($key),['content-length','content-type']))
+				$_SERVER[strtr(strtoupper($key),'-','_')]=$val;
+			else
+				$_SERVER['HTTP_'.strtr(strtoupper($key),'-','_')]=$val;
 		}
 		$this->hive['VERB']=$verb;
 		$this->hive['PATH']=$url['path'];

--- a/base.php
+++ b/base.php
@@ -1351,8 +1351,11 @@ final class Base extends Prefab implements ArrayAccess {
 		$GLOBALS['_POST']=$verb=='POST'?$args:[];
 		$GLOBALS['_REQUEST']=array_merge($GLOBALS['_GET'],$GLOBALS['_POST']);
 		foreach ($headers?:[] as $key=>$val){
-			$this->hive['HEADERS'][$key]=$val;
-			$_SERVER['HTTP_'.strtr(strtoupper($key),'-','_')]=$val;
+            $this->hive['HEADERS'][$key]=$val;
+		    if (in_array(strtolower($key),['content-length','content-type']))
+                $_SERVER[strtr(strtoupper($key),'-','_')]=$val;
+		    else
+                $_SERVER['HTTP_'.strtr(strtoupper($key),'-','_')]=$val;
 		}
 		$this->hive['VERB']=$verb;
 		$this->hive['PATH']=$url['path'];

--- a/base.php
+++ b/base.php
@@ -1350,9 +1350,10 @@ final class Base extends Prefab implements ArrayAccess {
 			$GLOBALS['_GET']=array_merge($GLOBALS['_GET'],$args);
 		$GLOBALS['_POST']=$verb=='POST'?$args:[];
 		$GLOBALS['_REQUEST']=array_merge($GLOBALS['_GET'],$GLOBALS['_POST']);
-		$this->hive['HEADERS']=$headers?:[];
-		foreach ($headers?:[] as $key=>$val)
+		foreach ($headers?:[] as $key=>$val){
+			$this->hive['HEADERS'][$key]=$val;
 			$_SERVER['HTTP_'.strtr(strtoupper($key),'-','_')]=$val;
+		}
 		$this->hive['VERB']=$verb;
 		$this->hive['PATH']=$url['path'];
 		$this->hive['URI']=$this->hive['BASE'].$url['path'];

--- a/base.php
+++ b/base.php
@@ -1350,6 +1350,7 @@ final class Base extends Prefab implements ArrayAccess {
 			$GLOBALS['_GET']=array_merge($GLOBALS['_GET'],$args);
 		$GLOBALS['_POST']=$verb=='POST'?$args:[];
 		$GLOBALS['_REQUEST']=array_merge($GLOBALS['_GET'],$GLOBALS['_POST']);
+		$this->hive['HEADERS']=$headers;
 		foreach ($headers?:[] as $key=>$val)
 			$_SERVER['HTTP_'.strtr(strtoupper($key),'-','_')]=$val;
 		$this->hive['VERB']=$verb;

--- a/base.php
+++ b/base.php
@@ -1350,7 +1350,7 @@ final class Base extends Prefab implements ArrayAccess {
 			$GLOBALS['_GET']=array_merge($GLOBALS['_GET'],$args);
 		$GLOBALS['_POST']=$verb=='POST'?$args:[];
 		$GLOBALS['_REQUEST']=array_merge($GLOBALS['_GET'],$GLOBALS['_POST']);
-		$this->hive['HEADERS']=$headers;
+		$this->hive['HEADERS']=$headers?:[];
 		foreach ($headers?:[] as $key=>$val)
 			$_SERVER['HTTP_'.strtr(strtoupper($key),'-','_')]=$val;
 		$this->hive['VERB']=$verb;


### PR DESCRIPTION
Although `$f3->get('SERVER.HTTP_[...]')` is able to return the correct result while mocking requests, it's not the case with `$f3->get('HEADERS.[...]')`.

This PR just sets this key with the specified headers in the `mock()` method.