### PR TITLE
Reroute fragment core

### DIFF
--- a/base.php
+++ b/base.php
@@ -1449,7 +1449,7 @@ final class Base extends Prefab implements ArrayAccess {
 			$url=$this->hive['REALM'];
 		if (is_array($url))
 			$url=call_user_func_array([$this,'alias'],$url);
-		elseif (preg_match('/^(?:@?([^\/()?]+)(?:(\(.+?)\))*(\?.+)*)/',
+		elseif (preg_match('/^(?:@?([^\/()?]+)(?:\((.+?)\))*(\?.+)*)/',
 			$url,$parts) &&
 			isset($this->hive['ALIASES'][$parts[1]]))
 			$url=$this->hive['ALIASES'][$parts[1]];

--- a/base.php
+++ b/base.php
@@ -1449,12 +1449,12 @@ final class Base extends Prefab implements ArrayAccess {
 			$url=$this->hive['REALM'];
 		if (is_array($url))
 			$url=call_user_func_array([$this,'alias'],$url);
-		elseif (preg_match('/^(?:@?([^\/()?]+)(?:\((.+?)\))*(\?.+)*)/',
+		elseif (preg_match('/^(?:@?([^\/()?]+)(?:\((.+?)\))*(\?[^#]+)*(#.+)*)/',
 			$url,$parts) &&
 			isset($this->hive['ALIASES'][$parts[1]]))
 			$url=$this->hive['ALIASES'][$parts[1]];
 		$url=$this->build($url,isset($parts[2])?$this->parse($parts[2]):[]).
-			(isset($parts[3])?$parts[3]:'');
+			(isset($parts[3])?$parts[3]:'').(isset($parts[4])?$parts[4]:'');
 		if (($handler=$this->hive['ONREROUTE']) &&
 			$this->call($handler,[$url,$permanent,$die])!==FALSE)
 			return;


### PR DESCRIPTION
Please find this PR moved from https://github.com/bcosca/fatfree/pull/1157

It should fix https://github.com/bcosca/fatfree/pull/1156 "Allow passing fragment to `reroute()`"