### PR TITLE
Don't copy event handlers to WebSocket clients

### DIFF
--- a/cli/ws.php
+++ b/cli/ws.php
@@ -328,8 +328,7 @@ class Agent {
 		$flag,
 		$verb,
 		$uri,
-		$headers,
-		$events;
+		$headers;
 
 	/**
 	*	Return server instance
@@ -400,8 +399,8 @@ class Agent {
 		if (is_bool($server->write($this->socket,$buf)))
 			return FALSE;
 		if (!in_array($op,[WS::Pong,WS::Close]) &&
-			isset($this->events['send']) &&
-			is_callable($func=$this->events['send']))
+			isset($this->server->events['send']) &&
+			is_callable($func=$this->server->events['send']))
 			$func($this,$op,$data);
 		return $data;
 	}
@@ -447,8 +446,8 @@ class Agent {
 			case WS::Text:
 				$data=trim($data);
 			case WS::Binary:
-				if (isset($this->events['receive']) &&
-					is_callable($func=$this->events['receive']))
+				if (isset($this->server->events['receive']) &&
+					is_callable($func=$this->server->events['receive']))
 					$func($this,$op,$data);
 				break;
 			}
@@ -460,8 +459,8 @@ class Agent {
 	*	Destroy object
 	**/
 	function __destruct() {
-		if (isset($this->events['disconnect']) &&
-			is_callable($func=$this->events['disconnect']))
+		if (isset($this->server->events['disconnect']) &&
+			is_callable($func=$this->server->events['disconnect']))
 			$func($this);
 	}
 
@@ -479,10 +478,9 @@ class Agent {
 		$this->verb=$verb;
 		$this->uri=$uri;
 		$this->headers=$hdrs;
-		$this->events=$server->events();
 
-		if (isset($this->events['connect']) &&
-			is_callable($func=$this->events['connect']))
+		if (isset($server->events['connect']) &&
+			is_callable($func=$server->events['connect']))
 			$func($this);
 	}
 


### PR DESCRIPTION
Currently, WebSocket agents (clients) copy the event handlers of the WebSocket server. Although it is unlikely that event handlers are modified as soon as the first Agent is spawned, copying the handlers can lead to unexpected side effects like outdated or missing handlers when working with older agents. This pull request accesses the handlers through the server object. A reference-based solution would also be possible.