### PR TITLE
DB\SQL: Fix handling of PDO prepare() errors

### DIFF
--- a/db/sql.php
+++ b/db/sql.php
@@ -257,7 +257,7 @@ class SQL {
 				$query->closecursor();
 				unset($query);
 			}
-			elseif (($error=$this->errorinfo()) && $error[0]!=\PDO::ERR_NONE) {
+			elseif (($error=$this->pdo->errorInfo()) && $error[0]!=\PDO::ERR_NONE) {
 				// PDO-level error occurred
 				if ($this->trans)
 					$this->rollback();


### PR DESCRIPTION
This changes the DB\SQL class to use the PDO instance's errorInfo() instead of attempting to call a nonexistent function. I believe this was what was originally intended with this code.