### PR TITLE
DB\SQL: Check for active transaction before rollback/commit

### DIFF
--- a/db/sql.php
+++ b/db/sql.php
@@ -66,7 +66,9 @@ class SQL {
 	*	@return bool
 	**/
 	function rollback() {
-		$out=$this->pdo->rollback();
+		$out=FALSE;
+		if ($this->pdo->inTransaction())
+			$out=$this->pdo->rollback();
 		$this->trans=FALSE;
 		return $out;
 	}
@@ -76,7 +78,9 @@ class SQL {
 	*	@return bool
 	**/
 	function commit() {
-		$out=$this->pdo->commit();
+		$out=FALSE;
+		if ($this->pdo->inTransaction())
+			$out=$this->pdo->commit();
 		$this->trans=FALSE;
 		return $out;
 	}


### PR DESCRIPTION
As PHP 8 [reports the actual transaction state](https://www.php.net/manual/en/migration80.incompatible.php#migration80.incompatible.pdo-mysql) in the MySQL PDO driver, running multiple statements with `DB\SQL::exec()` can break if any of those statements causes the transaction to end early (as is the case in things like schema changes). This was silently ignored in PHP 5/7, but under PHP 8 it can break without these additional checks.

This is not the only way to handle this change, and it may be something better left to the end-user. It may also affect performance and potentially break some behavior, though I didn't notice any major differences.

User code could instead just call `DB\SQL::exec()` in a loop when transactions cannot not be used, but this did affect [projects I maintain](https://github.com/Alanaktion/phproject/runs/1525736521) when running under PHP 8 so I figured I'd open a PR for feedback.