### PR TITLE
fixed capitalization of array key X-Http-Method-Override in headers

### DIFF
--- a/base.php
+++ b/base.php
@@ -2400,8 +2400,8 @@ final class Base extends Prefab implements ArrayAccess {
 					$headers[strtr(ucwords(strtolower(strtr(
 						substr($key,5),'_',' '))),' ','-')]=&$_SERVER[$key];
 		}
-		if (isset($headers['X-HTTP-Method-Override']))
-			$_SERVER['REQUEST_METHOD']=$headers['X-HTTP-Method-Override'];
+		if (isset($headers['X-Http-Method-Override']))
+			$_SERVER['REQUEST_METHOD']=$headers['X-Http-Method-Override'];
 		elseif ($_SERVER['REQUEST_METHOD']=='POST' && isset($_POST['_method']))
 			$_SERVER['REQUEST_METHOD']=strtoupper($_POST['_method']);
 		$scheme=isset($_SERVER['HTTPS']) && $_SERVER['HTTPS']=='on' ||


### PR DESCRIPTION
Each key of the HTTP request headers retrieved through getallheaders() is sent through `strtr(ucwords(strtolower(strtr($key,'-',' '))),' ','-')`, which uppercases only the first letter of each word. This means key 'X-HTTP-Method-Override' can never be found in the headers and in turn the function can not be used.