### PR TITLE
Beerpay.io no longer exists as a way to donate.

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,3 @@ For the main repository (demo package), see https://github.com/bcosca/fatfree
 For the test bench and unit tests, see https://github.com/f3-factory/fatfree-dev  
 For the user guide, see https://fatfreeframework.com/user-guide  
 For the documentation, see https://fatfreeframework.com/api-reference
-
-## Support on Beerpay
-Hey dude! Help me out for a couple of :beers:!
-
-[![Beerpay](https://beerpay.io/bcosca/fatfree-core/badge.svg?style=beer-square)](https://beerpay.io/bcosca/fatfree-core)  [![Beerpay](https://beerpay.io/bcosca/fatfree-core/make-wish.svg?style=flat-square)](https://beerpay.io/bcosca/fatfree-core?focus=wish)


### PR DESCRIPTION
The beerpay.io domain name dropped on and was registered by someone else. The beerpay.io project also appears to be dead according to the Twitter account https://twitter.com/beerpayio, so no alternative domain is known.