### PR TITLE
[Feature] Improve autoloader for snake case filenames.

### DIFF
--- a/base.php
+++ b/base.php
@@ -784,7 +784,7 @@ final class Base extends Prefab implements ArrayAccess {
 	*	@param $str string
 	**/
 	function snakecase($str) {
-		return strtolower(preg_replace('/(?!^)\p{Lu}/u','_\0',$str));
+		return ltrim(strtolower(str_replace('/_', '/', preg_replace('/[A-Z]([A-Z](?![a-z]))*/u', '_$0', $str))), '_');
 	}
 
 	/**
@@ -2229,7 +2229,8 @@ final class Base extends Prefab implements ArrayAccess {
 			if (($func && is_file($file=$func($auto.$class).'.php')) ||
 				is_file($file=$auto.$class.'.php') ||
 				is_file($file=$auto.strtolower($class).'.php') ||
-				is_file($file=strtolower($auto.$class).'.php'))
+				is_file($file=strtolower($auto.$class).'.php') ||
+				is_file($file=$auto.$this->snakecase($class).'.php'))
 				return require($file);
 	}
 


### PR DESCRIPTION
This solves #340 

## Changes:
- Improve snake case method 
- Enable autoload to look for snake case filenames based on pascal and camel case class names.

## Problem:
If you name your clases with more than one word, is probably that autoloader never finds the source file, unless you name the file without spaces:

Example:
```
  class ApiController {
     ...
  }
```
should be named as `apicontroller.php` to be loaded in the current F3 version, instead of `api_controller.php` that could be a standard convention to ease a more readable file structure and arrangement.

Edge case:
```
 classs App\BaseController\ApiBase {
   ...
 }
```

it gets more complicated, beside folder structure should be exactly the same as (probably non easy readable) namespace.

* Obviously, this not happens if you name your files exactly as the class name, covering the ideal scenario. But if you have some good code practices and conventions, this enhancement could be helpful.

## Solution:

The first step was to improve the `snake case` method, since with the curren approach on some cases, like namespaces and acronyms, was returning some extra underscores between folder names as output:

`Test/NameSpace/File` outputs `test/_name_space/_file`
`XMLParser` outputs `x_m_l_parser`

with the updated method this was fixed:

`Test/NameSpace/File` outputs `test/name_space/file`
`XMLParser` outputs `xml_parser`

Then implement the method on the autoload to add the case to look for the snake case filename:

```
                   foreach ($this->split($this->hive['PLUGINS'].';'.$path) as $auto)
			if (($func && is_file($file=$func($auto.$class).'.php')) ||
				is_file($file=$auto.$class.'.php') ||
				is_file($file=$auto.strtolower($class).'.php') ||
				is_file($file=strtolower($auto.$class).'.php') ||
				is_file($file=$auto.$this->snakecase($class).'.php'))
				return require($file);
```

### Test

Since there is no unit testing for this, I made some test based on the updated regex

```
$names = Array(
	'Hi', 'camelCase', 'PascalCase', 
	'snake_case', 'Test/NameSpace/File', 'XMLParser',
	'regionCode', 'dmaCode', 'countryCode',
	'inEU', 'euVATrate', 'locationAccuracyRadius',
	'currencyConverter', 'Camel2Snake'
);

// Old Regex
foreach($names as $item) {
	echo strtolower(preg_replace('/(?!^)\p{Lu}/u','_\0',$item));
	echo '<br>';
}

echo '<br>';
echo '<br>';

// New Regex
foreach($names as $item) {
	echo ltrim(strtolower(str_replace('/_', '/', preg_replace('/[A-Z]([A-Z](?![a-z]))*/u', '_$0', $item))), '_');
	echo '<br>';
}
``` 

Output:

```
// Old Regex

hi
camel_case
pascal_case
snake_case
test/_name_space/_file
x_m_l_parser
region_code
dma_code
country_code
in_e_u
eu_v_a_trate
location_accuracy_radius
currency_converter
camel2_snake

// New Regex

hi
camel_case
pascal_case
snake_case
test/name_space/file
xml_parser
region_code
dma_code
country_code
in_eu
eu_va_trate
location_accuracy_radius
currency_converter
camel2_snake
``` 
* [Tested](http://phptester.net/) on different php versions 5.3 to 8.1