### PR TITLE
base: Add CORS defaults that are not initialized

### DIFF
--- a/base.php
+++ b/base.php
@@ -2483,13 +2483,7 @@ final class Base extends Prefab implements ArrayAccess {
 			'CACHE'=>FALSE,
 			'CASELESS'=>TRUE,
 			'CLI'=>$cli,
-			'CORS'=>[
-				'headers'=>'',
-				'origin'=>FALSE,
-				'credentials'=>FALSE,
-				'expose'=>FALSE,
-				'ttl'=>0
-			],
+			'CORS'=>[],
 			'DEBUG'=>0,
 			'DIACRITICS'=>[],
 			'DNSBL'=>'',
@@ -2547,6 +2541,13 @@ final class Base extends Prefab implements ArrayAccess {
 			'VERB'=>&$_SERVER['REQUEST_METHOD'],
 			'VERSION'=>self::VERSION,
 			'XFRAME'=>'SAMEORIGIN'
+		];
+		$this->hive['CORS']+=[
+			'headers'=>'',
+			'origin'=>FALSE,
+			'credentials'=>FALSE,
+			'expose'=>FALSE,
+			'ttl'=>0
 		];
 		if (!headers_sent() && session_status()!=PHP_SESSION_ACTIVE) {
 			unset($jar['expire']);


### PR DESCRIPTION
The default configuration is already being used to fill in the gaps for applications. However, if you only want to override one or two of the CORS configuration subitems, the rest of the CORS defaults are not filled in (because an array element is already present). This is particularly problematic when the `credentials` subitem is not present, because it is assumed to exist: https://github.com/bcosca/fatfree-core/blob/4e46ebadecd2fe4aa0f05658858db51b7dccd06c/base.php#L1701

As a result, this also fixes either a PHP Notice or a Server 500 error depending on the system's configuration.