### PR TITLE
Cannot access property starting with "\0" bugfix

### DIFF
--- a/base.php
+++ b/base.php
@@ -881,9 +881,11 @@ final class Base extends Prefab implements ArrayAccess {
 					$arg=clone($arg);
 					$cast=is_a($arg,'IteratorAggregate')?
 						iterator_to_array($arg):get_object_vars($arg);
-					foreach ($cast as $key=>$val)
+					foreach ($cast as $key=>$val) {
+						$key = trim($key);
 						$arg->$key=$this->recursive(
 							$val,$func,array_merge($stack,[$arg]));
+					}
 				}
 				return $arg;
 			case 'array':


### PR DESCRIPTION
Bugfix to:
Cannot access property starting with "\0" [<...>\vendor\bcosca\fatfree-core\base.php:885]

Loading the site causes the above message to be the only thing that displays at the top of the webpage. The "\0" is a NUL-byte as per https://www.php.net/manual/en/function.trim.php. With the bug, keys in a particular foreach loop in base.php were getting cut into pieces it appears. I tried checking if each $key was set, however, running a counter on it revealed that only 1 out of several keys were getting checked that way. Using trim() revealed that several keys were being looped through, so I went with that, though, I'm not sure if removing the "\0" could cause a problem somewhere else.

Also, by checking with a counter in the loop, using trim() vs just commenting out the call to recursive() proved that all keys were checked either way, and without, only 2 were getting checked before the crashes. So I'm assuming trim() is the way to fix this, though I'm not 100% sure.

The bug occurs when either or both of the following two conditions are true (depending on whether using the F3 way of managing SESSION or not):

1) When using a setup where the F3 Base::instance() is passed into an object and set as a property of that object (aka member variable) in the project's root index.php, 

2) The F3 method of setting SESSION variables is not being used, and instead $_SESSION is being used to get and set session variables and session_start() is being called at the top of index.php

It was easiest to get consistent behavior with the bug by only using $_SESSION for gets and sets, with session_start() also in the index.php. However, this bug would occasionally still happen when not using session_start() anywhere, while only using the F3 way of dealing with SESSION: $this->_f3->get('SESSION.anything'). I couldn't get a reliable test going to replicate the bug that way though, so here I'm illustrating the more easy to reproduce version.

It would happen either upon immediately visiting the site, or, after refreshing once already on the site.

The bug appears to be occurring somewhere inside the session_start() call, commenting it in and out on a setup that was using $_SESSION instead of the F3 way of accessing SESSION would cause the bug to not happen, of course, SESSION does not work if only using $_SESSION so it's still a bug. According to the docs, it is the user's preference whether to use the F3 handing of SESSION or the $_SESSION way:

https://fatfreeframework.com/3.8/framework-variables

"If you use $_SESSION (or session-related functions) directly, instead of the framework variable SESSION, your application becomes responsible for managing sessions."

Starting at line 884 of base.php, the fix is as follows (trim() call and brackets for the foreach):

    foreach ($cast as $key=>$val) {
        $key = trim($key);
        $arg->$key=$this->recursive(
            $val,$func,array_merge($stack,[$arg]));
    }

echo inside the foreach without trim():
__PHP_Incomplete_Class_NameApplicant_fname

echo inside the foreach with trim():
__PHP_Incomplete_Class_NameApplicant_fnameApplicant_lnameApplicant_emailApplicant_stateApplicant_phoneApplicant_githubApplicant_experienceApplicant_relocateApplicant_bio

Pattern that causes the crash most reliably:

Inside index.php:

    ...

    session_start(); // incorrect location, this should be below require_once(), however, to easily  
                     // get this bug, I'm using session_start() there, and only using $_SESSION for 
                     // illustration. This is how the bug can be most reliably reproduced. When  
                     // using the F3 way of accessing SESSION (no use of session_start() and only 
                     // using $f3->set('SESSION.whatever') ways), it's the same bug on
                     // base.php 885 that occurs, it is just much harder to reproduce that way.
    require_once('vendor/autoload.php');

    // init base class
    $f3 = Base::instance();
    $controller = new Controller($f3);

    /**
    * Default root route
    */
    $f3->route('GET /', function()
    {
        $GLOBALS['controller']->route_root();
    });

    ...

Inside controller.php:

    ...

    /**
    * Controller class for routes
    * @param $f3 Base instance
    *
    * only using $_SESSION in route functions here for easy bug reproduction
    *
    */
    class Controller
    {
        private $_f3;

        function __construct($f3)
        {
            $this->_f3 = $f3;   
        }

        /**
        * Runs code for root view routing
        */
        function route_root()
        {
            // home page
            $view = new Template();
            echo $view->render('views/home.html');
        }
	
    ...

Thank you!