### PR TITLE
Modified Preview::build() to allow for Twig template comments {# #}

### DIFF
--- a/base.php
+++ b/base.php
@@ -3168,7 +3168,7 @@ class Preview extends View {
 	**/
 	protected function build($node) {
 		return preg_replace_callback(
-			'/\{~(.+?)~\}|\{\*(.+?)\*\}|\{\-(.+?)\-\}|'.
+			'/\{~(.+?)~\}|\{[\*|\#](.+?)[\*|\#]\}|\{\-(.+?)\-\}|'.
 			'\{\{(.+?)\}\}((\r?\n)*)/s',
 			function($expr) {
 				if ($expr[1])


### PR DESCRIPTION
When using Twig files and key commands to inject comments, the IDE uses {# #}.  F3 by default uses {* *}.  I've modified the regex in the Preview::build() method to allow for * or # to identify comments.