### PR TITLE
Existence of $http_response_header in web.php triggers PHP 8.5 deprecation warning

### DIFF
--- a/web.php
+++ b/web.php
@@ -425,9 +425,12 @@ class Web extends Prefab {
 			stream_context_create(['http'=>$options]));
 		if (PHP_VERSION_ID >= 80500)
 			$headers=http_get_last_response_headers() ?: [];
-		else
-			$headers=isset($http_response_header)?
-				$http_response_header:[];
+		else {
+			$locals=get_defined_vars();
+			$headers=isset($locals['http_response_header']) &&
+				is_array($locals['http_response_header'])?
+				$locals['http_response_header']:[];
+		}
 		$err='';
 		if (is_string($body)) {
 			$match=NULL;


### PR DESCRIPTION
In PHP 8.5 the deprecation is raised just by referencing $http_response_header, even in an unreachable else. 

This PR is a patch so that PHP versions below 80500 can still function without triggering deprecation warning with 8.5 or later.