### PR TITLE
🐛 Fix PHP 8.2 deprecation when using DB\Jig with FORMAT_Serialized

### DIFF
--- a/base.php
+++ b/base.php
@@ -974,8 +974,15 @@ final class Base extends Prefab implements ArrayAccess {
 						// skip inaccessible properties #350
 						if (!$it && !isset($arg->$key))
 							continue;
-						$arg->$key=$this->recursive(
-							$val,$func,array_merge($stack,[$arg]));
+						$value = $this->recursive(
+							$val, $func, array_merge($stack, [$arg])
+						);
+
+						if ($arg instanceof \ArrayObject) {
+							$arg[$key] = $value;
+						} else {
+							$arg->$key = $value;
+						}
 					}
 				}
 				return $arg;


### PR DESCRIPTION
### 🐛 Fix PHP 8.2 deprecation when using DB\Jig with FORMAT_Serialized

PHP 8.2 deprecates dynamic property creation.
When using `DB\Jig` with `FORMAT_Serialized`, this can trigger warnings like:

```text
Creation of dynamic property ArrayObject::$0 is deprecated
```

---

### 🔁 Steps to reproduce

```php
$db = new \DB\Jig($path, \DB\Jig::FORMAT_Serialized);
$data = $db->read('collection');
```

Then pass the data through template rendering (or any flow that reaches `Base::recursive()`).

---

### ❌ Current behavior

When `$arg` is an instance of `ArrayObject` and `$key` is numeric, the following line in `Base::recursive()`:

```php
$arg->$key = ...
```

attempts to create a dynamic property like `$arg->0`, which is deprecated in PHP 8.2.

---

### ✅ Expected behavior

No deprecation warnings when handling data from `DB\Jig::FORMAT_Serialized`.

---

### 🧠 Additional context

* The issue does **not occur** when using `DB\Jig::FORMAT_JSON`
* JSON returns arrays, while `FORMAT_Serialized` may return `ArrayObject` instances
* The issue arises specifically when `ArrayObject` is treated like a regular object inside `recursive()`

---

### 💡 Proposed fix

Handle `ArrayObject` using array access instead of dynamic properties:

```php
$value = $this->recursive(
    $val, $func, array_merge($stack, [$arg])
);

if ($arg instanceof \ArrayObject) {
    $arg[$key] = $value;
} else {
    $arg->$key = $value;
}
```

---

### 🚀 Impact

* Fixes PHP 8.2 deprecation warnings
* Maintains backward compatibility
* Prevents potential breaking changes in future PHP versions (e.g. PHP 9)