### PR TITLE
fix: IP spoofing, header case sensitivity, URL scheme validation, XXE protection

### DIFF
--- a/base.php
+++ b/base.php
@@ -1394,12 +1394,15 @@ final class Base extends Prefab implements ArrayAccess {
 	**/
 	function ip() {
 		$headers=$this->hive['HEADERS'];
-		return isset($headers['Client-IP'])?
-			$headers['Client-IP']:
-			(isset($headers['X-Forwarded-For'])?
-				explode(',',$headers['X-Forwarded-For'])[0]:
-				(isset($_SERVER['REMOTE_ADDR'])?
-					$_SERVER['REMOTE_ADDR']:''));
+		$remote=isset($_SERVER['REMOTE_ADDR'])?$_SERVER['REMOTE_ADDR']:'';
+		$trusted=$this->hive['TRUSTED']??[];
+		if ($remote && $trusted && in_array($remote,$trusted)) {
+			if (isset($headers['Client-IP']))
+				return $headers['Client-IP'];
+			if (isset($headers['X-Forwarded-For']))
+				return explode(',',$headers['X-Forwarded-For'])[0];
+		}
+		return $remote;
 	}
 
 	/**
@@ -2651,6 +2654,7 @@ final class Base extends Prefab implements ArrayAccess {
 			'SERIALIZER'=>extension_loaded($ext='igbinary')?$ext:'php',
 			'TEMP'=>'tmp/',
 			'TIME'=>&$_SERVER['REQUEST_TIME_FLOAT'],
+			'TRUSTED'=>[],
 			'TZ'=>@date_default_timezone_get(),
 			'UI'=>'./',
 			'UNLOAD'=>NULL,

--- a/web.php
+++ b/web.php
@@ -589,7 +589,7 @@ class Web extends Prefab {
 		if (is_string($new))
 			$new=[$new];
 		foreach ($new as $hdr) {
-			$old=preg_grep('/'.preg_quote(strstr($hdr,':',TRUE),'/').':.+/',
+			$old=preg_grep('/'.preg_quote(strstr($hdr,':',TRUE),'/').':.+/i',
 				$old,PREG_GREP_INVERT);
 			array_push($old,$hdr);
 		}
@@ -613,7 +613,7 @@ class Web extends Prefab {
 				($url[0]!='/'?($fw->BASE.'/'):'').$url;
 			$parts=parse_url($url);
 		}
-		elseif (!preg_match('/https?/',$parts['scheme']))
+		elseif (!preg_match('/^https?$/i',$parts['scheme']))
 			return FALSE;
 		if (!is_array($options))
 			$options=[];
@@ -847,8 +847,15 @@ class Web extends Prefab {
 			return FALSE;
 		// Suppress errors caused by invalid XML structures
 		libxml_use_internal_errors(TRUE);
-		$xml=simplexml_load_string($data['body'],
-			NULL,LIBXML_NOBLANKS|LIBXML_NOERROR);
+		if (PHP_VERSION_ID<80000) {
+			$prev=libxml_disable_entity_loader(TRUE);
+			$xml=simplexml_load_string($data['body'],
+				NULL,LIBXML_NOBLANKS|LIBXML_NOERROR);
+			libxml_disable_entity_loader($prev);
+		}
+		else
+			$xml=simplexml_load_string($data['body'],
+				NULL,LIBXML_NOBLANKS|LIBXML_NOERROR);
 		if (!is_object($xml))
 			return FALSE;
 		$out=[];


### PR DESCRIPTION
Fixes four security issues:

- **IP spoofing via X-Forwarded-For** — `ip()` trusted `Client-IP` and `X-Forwarded-For` headers unconditionally. Now only honors them when `REMOTE_ADDR` is in a new `TRUSTED` hive config (defaults to empty).
- **Duplicate headers from case-sensitive replacement** — `subst()` used case-sensitive `preg_grep`, so `content-type` and `Content-Type` coexisted. Now case-insensitive.
- **Weak URL scheme validation** — `request()` used unanchored `/https?/` regex, allowing schemes like `httpx://`. Now anchored `/^https?$/i`.
- **XXE in RSS parsing** — `rss()` parsed XML without disabling external entity loading. Now calls `libxml_disable_entity_loader()` (guarded for PHP 8.0+ where it's deprecated and unnecessary).